### PR TITLE
fix: correct module path and code formatting (closes #18)

### DIFF
--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"linktadoru/internal/cmd"
+	"github.com/masahif/linktadoru/internal/cmd"
 )
 
 // Version information set by build flags

--- a/cmd/crawler/main_test.go
+++ b/cmd/crawler/main_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"linktadoru/internal/cmd"
+	"github.com/masahif/linktadoru/internal/cmd"
 )
 
 func TestVersionVariables(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module linktadoru
+module github.com/masahif/linktadoru
 
 go 1.23.0
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -14,9 +14,9 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 
-	"linktadoru/internal/config"
-	"linktadoru/internal/crawler"
-	"linktadoru/internal/storage"
+	"github.com/masahif/linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/crawler"
+	"github.com/masahif/linktadoru/internal/storage"
 )
 
 var (
@@ -221,17 +221,17 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	if len(cfg.SeedURLs) == 0 {
 		// No seed URLs provided, check if database exists for resume
 		if _, err := os.Stat(cfg.DatabasePath); os.IsNotExist(err) {
-			return fmt.Errorf("no URLs provided and no existing database found at %s\nUsage: %s [URLs...] or ensure database exists for resume operation", 
+			return fmt.Errorf("no URLs provided and no existing database found at %s\nUsage: %s [URLs...] or ensure database exists for resume operation",
 				cfg.DatabasePath, os.Args[0])
 		}
-		
+
 		// Database exists, but let's check if it has any queued items
 		// Create a temporary storage instance to check queue status
 		tempStorage, err := storage.NewSQLiteStorage(cfg.DatabasePath)
 		if err != nil {
 			return fmt.Errorf("failed to open database %s: %w", cfg.DatabasePath, err)
 		}
-		
+
 		// Check if queue has any items (queued or processing)
 		hasWork, err := tempStorage.HasQueuedItems()
 		if err != nil {
@@ -243,13 +243,13 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 		if closeErr := tempStorage.Close(); closeErr != nil {
 			return fmt.Errorf("failed to close temporary storage: %w", closeErr)
 		}
-		
+
 		if !hasWork {
 			fmt.Printf("No URLs provided and no queued items found in database %s\n", cfg.DatabasePath)
 			fmt.Printf("Nothing to crawl. Exiting.\n")
 			return nil
 		}
-		
+
 		fmt.Printf("Resuming crawl from existing database: %s\n", cfg.DatabasePath)
 	}
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"linktadoru/internal/config"
-	"linktadoru/internal/storage"
+	"github.com/masahif/linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/storage"
 )
 
 func TestSetVersionInfo(t *testing.T) {
@@ -232,7 +232,7 @@ func TestRunCrawlerStartupValidation(t *testing.T) {
 	})
 
 	t.Run("NoURLsEmptyDB", func(t *testing.T) {
-		// Reset viper for each subtest  
+		// Reset viper for each subtest
 		viper.Reset()
 
 		// Create an empty database

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/config"
 )
 
 // DefaultCrawler implements the Crawler interface

--- a/internal/crawler/integration_test.go
+++ b/internal/crawler/integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/config"
 )
 
 // TestStartStop tests the Start and Stop methods

--- a/internal/crawler/limit_test.go
+++ b/internal/crawler/limit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/config"
 )
 
 // MockStorage implements Storage interface for testing

--- a/internal/crawler/page_processor.go
+++ b/internal/crawler/page_processor.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"linktadoru/internal/parser"
+	"github.com/masahif/linktadoru/internal/parser"
 )
 
 // DefaultPageProcessor implements the PageProcessor interface

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -3,7 +3,7 @@ package crawler
 import (
 	"testing"
 
-	"linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/config"
 )
 
 func TestShouldCrawlURL(t *testing.T) {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"linktadoru/internal/crawler"
+	"github.com/masahif/linktadoru/internal/crawler"
 	// SQLite database driver (CGO-free)
 	_ "modernc.org/sqlite"
 )
@@ -390,11 +390,11 @@ func (s *SQLiteStorage) HasQueuedItems() (bool, error) {
 		FROM pages 
 		WHERE status IN ('queued', 'processing')
 	`).Scan(&count)
-	
+
 	if err != nil {
 		return false, fmt.Errorf("failed to check queued items: %w", err)
 	}
-	
+
 	return count > 0, nil
 }
 

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"linktadoru/internal/crawler"
+	"github.com/masahif/linktadoru/internal/crawler"
 )
 
 func TestSQLiteStorage(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixed module path from `linktadoru` to `github.com/masahif/linktadoru` in go.mod
- Updated all import statements to use correct module path
- Applied gofmt formatting to resolve code style issues

## Problem
Go Report Card was showing grade C due to:
1. Incorrect module path causing download errors from proxy.golang.org
2. Code formatting issues in several files

## Changes
- **go.mod**: Fixed module path
- **All Go files**: Updated import paths from `linktadoru/internal/*` to `github.com/masahif/linktadoru/internal/*`
- **Formatting**: Fixed gofmt issues in internal/cmd/root.go, internal/cmd/root_test.go, and internal/storage/sqlite.go

## Test plan
- [x] All tests pass locally
- [x] Code builds successfully
- [x] golangci-lint passes without errors
- [ ] CI pipeline completes successfully
- [ ] Go Report Card grade improves after merge

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)