### PR TITLE
feat: add same-host crawling restriction by default (closes #23)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -64,6 +64,7 @@ func init() {
 	rootCmd.Flags().DurationP("timeout", "t", 30*time.Second, "HTTP request timeout")
 	rootCmd.Flags().StringP("user-agent", "u", "LinkTadoru/1.0", "HTTP User-Agent header")
 	rootCmd.Flags().Bool("ignore-robots", false, "Ignore robots.txt rules")
+	rootCmd.Flags().Bool("follow-external-hosts", false, "Allow crawling external hosts")
 	rootCmd.Flags().IntP("limit", "l", 0, "Stop after N pages (0=unlimited)")
 
 	// Authentication type flag
@@ -100,6 +101,7 @@ func init() {
 		{"request_timeout", "timeout"},
 		{"user_agent", "user-agent"},
 		{"ignore_robots", "ignore-robots"},
+		{"follow_external_hosts", "follow-external-hosts"},
 		{"limit", "limit"},
 		{"include_patterns", "include-patterns"},
 		{"exclude_patterns", "exclude-patterns"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,8 +57,9 @@ type CrawlConfig struct {
 	RequestDelay   float64       `mapstructure:"request_delay" yaml:"request_delay"`     // Delay between requests
 	RequestTimeout time.Duration `mapstructure:"request_timeout" yaml:"request_timeout"` // HTTP request timeout
 	UserAgent      string        `mapstructure:"user_agent" yaml:"user_agent"`           // HTTP User-Agent header
-	IgnoreRobots   bool          `mapstructure:"ignore_robots" yaml:"ignore_robots"`     // Whether to ignore robots.txt
-	Limit          int           `mapstructure:"limit" yaml:"limit"`                     // Stop after N pages
+	IgnoreRobots        bool          `mapstructure:"ignore_robots" yaml:"ignore_robots"`                 // Whether to ignore robots.txt
+	FollowExternalHosts bool          `mapstructure:"follow_external_hosts" yaml:"follow_external_hosts"` // Whether to crawl external hosts
+	Limit               int           `mapstructure:"limit" yaml:"limit"`                                 // Stop after N pages
 
 	// Authentication
 	Auth *Auth `mapstructure:"auth" yaml:"auth"` // Authentication configuration
@@ -77,13 +78,14 @@ type CrawlConfig struct {
 // DefaultConfig returns a configuration with default values
 func DefaultConfig() *CrawlConfig {
 	return &CrawlConfig{
-		Concurrency:    2,   // Reduced from 10 to 2
-		RequestDelay:   0.1, // 100ms in seconds // Reduced from 1s to 0.1s
-		RequestTimeout: 30 * time.Second,
-		UserAgent:      "LinkTadoru/1.0",
-		IgnoreRobots:   false,
-		Limit:          0, // unlimited
-		DatabasePath:   "./linktadoru.db",
+		Concurrency:         2,     // Reduced from 10 to 2
+		RequestDelay:        0.1,   // 100ms in seconds // Reduced from 1s to 0.1s
+		RequestTimeout:      30 * time.Second,
+		UserAgent:           "LinkTadoru/1.0",
+		IgnoreRobots:        false,
+		FollowExternalHosts: false, // Default to same-host only for safety
+		Limit:               0,     // unlimited
+		DatabasePath:        "./linktadoru.db",
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,10 @@ func TestDefaultConfig(t *testing.T) {
 		t.Errorf("Expected ignore robots false, got %v", cfg.IgnoreRobots)
 	}
 
+	if cfg.FollowExternalHosts {
+		t.Errorf("Expected follow external hosts false, got %v", cfg.FollowExternalHosts)
+	}
+
 	if cfg.Limit != 0 {
 		t.Errorf("Expected limit 0, got %d", cfg.Limit)
 	}

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -1,6 +1,7 @@
 package crawler
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/masahif/linktadoru/internal/config"
@@ -125,14 +126,265 @@ func TestShouldCrawlURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			crawler := &DefaultCrawler{
 				config: &config.CrawlConfig{
-					IncludePatterns: tt.includePatterns,
-					ExcludePatterns: tt.excludePatterns,
+					IncludePatterns:     tt.includePatterns,
+					ExcludePatterns:     tt.excludePatterns,
+					FollowExternalHosts: true, // Allow all hosts for legacy tests
 				},
+				allowedHosts: []string{}, // Empty list but external hosts allowed
 			}
 
 			result := crawler.shouldCrawlURL(tt.url)
 			if result != tt.expected {
 				t.Errorf("shouldCrawlURL() = %v, expected %v for URL %s", result, tt.expected, tt.url)
+			}
+		})
+	}
+}
+
+func TestIsAllowedHost(t *testing.T) {
+	tests := []struct {
+		name             string
+		seedURLs         []string
+		followExternal   bool
+		targetURL        string
+		expected         bool
+	}{
+		{
+			name:           "Same host allowed - exact match",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "https://example.com/page",
+			expected:       true,
+		},
+		{
+			name:           "Different host blocked",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "https://other.com/page",
+			expected:       false,
+		},
+		{
+			name:           "Different scheme blocked",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "http://example.com/page",
+			expected:       false,
+		},
+		{
+			name:           "Different port blocked",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "https://example.com:8080/page",
+			expected:       false,
+		},
+		{
+			name:           "Subdomain blocked",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "https://www.example.com/page",
+			expected:       false,
+		},
+		{
+			name:           "Multiple seed URLs - first host matches",
+			seedURLs:       []string{"https://example.com", "https://blog.com"},
+			followExternal: false,
+			targetURL:      "https://example.com/page",
+			expected:       true,
+		},
+		{
+			name:           "Multiple seed URLs - second host matches",
+			seedURLs:       []string{"https://example.com", "https://blog.com"},
+			followExternal: false,
+			targetURL:      "https://blog.com/post",
+			expected:       true,
+		},
+		{
+			name:           "Multiple seed URLs - no match",
+			seedURLs:       []string{"https://example.com", "https://blog.com"},
+			followExternal: false,
+			targetURL:      "https://other.com/page",
+			expected:       false,
+		},
+		{
+			name:           "External hosts allowed - different host",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: true,
+			targetURL:      "https://other.com/page",
+			expected:       true,
+		},
+		{
+			name:           "External hosts allowed - same host",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: true,
+			targetURL:      "https://example.com/page",
+			expected:       true,
+		},
+		{
+			name:           "Invalid URL",
+			seedURLs:       []string{"https://example.com"},
+			followExternal: false,
+			targetURL:      "invalid-url",
+			expected:       false,
+		},
+		{
+			name:           "Empty seed URLs - external disabled",
+			seedURLs:       []string{},
+			followExternal: false,
+			targetURL:      "https://example.com/page",
+			expected:       false,
+		},
+		{
+			name:           "Empty seed URLs - external enabled",
+			seedURLs:       []string{},
+			followExternal: true,
+			targetURL:      "https://example.com/page",
+			expected:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a crawler with the test configuration
+			config := &config.CrawlConfig{
+				SeedURLs:            tt.seedURLs,
+				FollowExternalHosts: tt.followExternal,
+			}
+
+			// Extract allowed hosts like NewCrawler does
+			allowedHosts := make([]string, 0, len(config.SeedURLs))
+			for _, seedURL := range config.SeedURLs {
+				if parsedURL, err := url.Parse(seedURL); err == nil {
+					host := parsedURL.Scheme + "://" + parsedURL.Host
+					// Avoid duplicates
+					found := false
+					for _, existing := range allowedHosts {
+						if existing == host {
+							found = true
+							break
+						}
+					}
+					if !found {
+						allowedHosts = append(allowedHosts, host)
+					}
+				}
+			}
+
+			crawler := &DefaultCrawler{
+				config:       config,
+				allowedHosts: allowedHosts,
+			}
+
+			result := crawler.isAllowedHost(tt.targetURL)
+			if result != tt.expected {
+				t.Errorf("isAllowedHost() = %v, expected %v for URL %s with seeds %v", result, tt.expected, tt.targetURL, tt.seedURLs)
+			}
+		})
+	}
+}
+
+func TestShouldCrawlURLWithHostFiltering(t *testing.T) {
+	tests := []struct {
+		name             string
+		seedURLs         []string
+		followExternal   bool
+		includePatterns  []string
+		excludePatterns  []string
+		targetURL        string
+		expected         bool
+	}{
+		{
+			name:            "Same host - no patterns",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  false,
+			includePatterns: []string{},
+			excludePatterns: []string{},
+			targetURL:       "https://example.com/page",
+			expected:        true,
+		},
+		{
+			name:            "External host blocked - no patterns",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  false,
+			includePatterns: []string{},
+			excludePatterns: []string{},
+			targetURL:       "https://other.com/page",
+			expected:        false,
+		},
+		{
+			name:            "External host allowed - no patterns",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  true,
+			includePatterns: []string{},
+			excludePatterns: []string{},
+			targetURL:       "https://other.com/page",
+			expected:        true,
+		},
+		{
+			name:            "Same host - matches include pattern",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  false,
+			includePatterns: []string{".*example\\.com.*"},
+			excludePatterns: []string{},
+			targetURL:       "https://example.com/page",
+			expected:        true,
+		},
+		{
+			name:            "External host - matches include pattern but blocked by host filter",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  false,
+			includePatterns: []string{".*other\\.com.*"},
+			excludePatterns: []string{},
+			targetURL:       "https://other.com/page",
+			expected:        false, // Host filter takes precedence
+		},
+		{
+			name:            "Same host - blocked by exclude pattern",
+			seedURLs:        []string{"https://example.com"},
+			followExternal:  false,
+			includePatterns: []string{},
+			excludePatterns: []string{"\\.pdf$"},
+			targetURL:       "https://example.com/file.pdf",
+			expected:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a crawler with the test configuration
+			config := &config.CrawlConfig{
+				SeedURLs:            tt.seedURLs,
+				FollowExternalHosts: tt.followExternal,
+				IncludePatterns:     tt.includePatterns,
+				ExcludePatterns:     tt.excludePatterns,
+			}
+
+			// Extract allowed hosts like NewCrawler does
+			allowedHosts := make([]string, 0, len(config.SeedURLs))
+			for _, seedURL := range config.SeedURLs {
+				if parsedURL, err := url.Parse(seedURL); err == nil {
+					host := parsedURL.Scheme + "://" + parsedURL.Host
+					// Avoid duplicates
+					found := false
+					for _, existing := range allowedHosts {
+						if existing == host {
+							found = true
+							break
+						}
+					}
+					if !found {
+						allowedHosts = append(allowedHosts, host)
+					}
+				}
+			}
+
+			crawler := &DefaultCrawler{
+				config:       config,
+				allowedHosts: allowedHosts,
+			}
+
+			result := crawler.shouldCrawlURL(tt.targetURL)
+			if result != tt.expected {
+				t.Errorf("shouldCrawlURL() = %v, expected %v for URL %s with config %+v", result, tt.expected, tt.targetURL, config)
 			}
 		})
 	}

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -7,6 +7,7 @@ request_delay: 0.1           # Delay between requests in seconds (default: 0.1, 
 request_timeout: 30.0        # HTTP request timeout in seconds
 user_agent: "LinkTadoru/1.0"       # User-Agent header (version will be dynamically set if not specified)
 ignore_robots: false        # Whether to ignore robots.txt rules (default: respect robots.txt)
+follow_external_hosts: false # Whether to crawl external hosts (default: same-host only for safety)
 limit: 0                    # Stop after N pages (0 = unlimited)
 
 # Database configuration
@@ -85,3 +86,7 @@ headers:
 #   - "/login"
 #   - "/admin"
 #   - "\\.pdf$"
+
+# Cross-site crawling (follow external links):
+# follow_external_hosts: true
+# limit: 100  # Recommended when crawling multiple sites


### PR DESCRIPTION
## Summary
- Implement same-host crawling restriction by default for safer operation
- Add `--follow-external-hosts` CLI flag to enable cross-site crawling when needed
- External links are still recorded in `links` table for comprehensive link analysis
- Maintain full backward compatibility through configuration options

## Changes Made

### Configuration
- Added `FollowExternalHosts` field to `CrawlConfig` with default `false`
- Added `--follow-external-hosts` CLI flag
- Added `LT_FOLLOW_EXTERNAL_HOSTS` environment variable support
- Updated `linktadoru.yml.example` with new option and usage examples

### Core Logic
- Implemented host filtering in crawler's `shouldCrawlURL()` method
- Added `isAllowedHost()` helper function for precise host matching
- Host comparison includes scheme, hostname, and port for security
- Extracts allowed hosts from seed URLs during crawler initialization

### Testing
- Comprehensive unit tests for host comparison logic (13 test cases)
- Integration tests for same-host vs external host scenarios
- Updated existing URL filtering tests to maintain compatibility
- All tests pass with no regressions

## Behavior Changes

### Default Behavior (Breaking Change)
- **Before**: Crawls all discovered links regardless of host
- **After**: Only crawls pages from same host as initial URL(s)
- **External links**: Still recorded in `links` table but not crawled

### Migration Path for Existing Users
```bash
# Restore previous behavior
./linktadoru --follow-external-hosts https://example.com

# Or via environment variable
export LT_FOLLOW_EXTERNAL_HOSTS=true
./linktadoru https://example.com

# Or via config file
echo "follow_external_hosts: true" > linktadoru.yml
```

## Examples

### Same-Host Only (Default)
```bash
./linktadoru https://example.com
# Only crawls pages on example.com
# Records all links (internal and external) in database
```

### Cross-Site Crawling
```bash
./linktadoru --follow-external-hosts https://example.com
# Crawls all discovered links regardless of host
# Equivalent to previous behavior
```

## Test Plan
- [x] Unit tests for host comparison logic
- [x] Integration tests for crawling behavior 
- [x] Configuration parsing tests (CLI, env, YAML)
- [x] Backward compatibility tests
- [x] Manual testing with live websites
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)