### PR TITLE
Fix URL filtering and same-host validation logic (closes #38)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type CrawlConfig struct {
 	// URL filtering
 	IncludePatterns []string `mapstructure:"include_patterns" yaml:"include_patterns"` // Regex patterns for URLs to include
 	ExcludePatterns []string `mapstructure:"exclude_patterns" yaml:"exclude_patterns"` // Regex patterns for URLs to exclude
+	AllowedSchemes  []string `mapstructure:"allowed_schemes" yaml:"allowed_schemes"`   // Allowed URL schemes (e.g., https://, http://)
 
 	// HTTP Headers
 	Headers []string `mapstructure:"headers" yaml:"headers"` // Custom HTTP headers
@@ -93,6 +94,7 @@ func DefaultConfig() *CrawlConfig {
 		FollowExternalHosts: false, // Default to same-host only for safety
 		Limit:               0,     // unlimited
 		DatabasePath:        "./linktadoru.db",
+		AllowedSchemes:      []string{"https://", "http://"}, // Default allowed URL schemes
 		// Logging defaults
 		LogLevel:      "info",
 		LogFile:       "",    // Empty means no file logging by default

--- a/internal/crawler/page_processor.go
+++ b/internal/crawler/page_processor.go
@@ -11,13 +11,20 @@ import (
 
 // DefaultPageProcessor implements the PageProcessor interface
 type DefaultPageProcessor struct {
-	httpClient *HTTPClient
+	httpClient     *HTTPClient
+	allowedSchemes []string
 }
 
-// NewPageProcessor creates a new page processor
+// NewPageProcessor creates a new page processor with default schemes
 func NewPageProcessor(httpClient *HTTPClient) PageProcessor {
+	return NewPageProcessorWithSchemes(httpClient, []string{"https://", "http://"})
+}
+
+// NewPageProcessorWithSchemes creates a new page processor with custom allowed schemes
+func NewPageProcessorWithSchemes(httpClient *HTTPClient, allowedSchemes []string) PageProcessor {
 	return &DefaultPageProcessor{
-		httpClient: httpClient,
+		httpClient:     httpClient,
+		allowedSchemes: allowedSchemes,
 	}
 }
 
@@ -74,8 +81,8 @@ func (p *DefaultPageProcessor) Process(ctx context.Context, url string) (*PageRe
 		return result, nil
 	}
 
-	// Parse HTML
-	htmlParser, err := parser.NewHTMLParser(resp.FinalURL)
+	// Parse HTML with configured allowed schemes
+	htmlParser, err := parser.NewHTMLParserWithSchemes(resp.FinalURL, p.allowedSchemes)
 	if err != nil {
 		return result, nil
 	}


### PR DESCRIPTION
## Summary

This PR fixes critical URL filtering bugs reported in issue #38:

- External URLs being processed when `--follow-external-hosts` is disabled
- Invalid URL schemes (tel:, mailto:, chrome-extension:) being stored in the database as crawl errors
- Same-host validation not working properly with prefix-based matching

## Changes Made

### 🔧 Core Fixes

1. **URL Scheme Filtering** (`internal/parser/html_parser.go`)
   - Added `isAllowedScheme()` method with proper detection for tel:, mailto:, chrome-extension:, javascript: schemes
   - Filters invalid schemes at HTML parsing stage before database storage
   - Supports configurable allowed schemes with secure defaults

2. **Configuration Support** (`internal/config/config.go`)
   - Added `AllowedSchemes []string` field to `CrawlConfig`
   - Default schemes: `["https://", "http://"]`
   - Backward compatible with existing configurations

3. **Enhanced Host Validation** (`internal/crawler/crawler.go`)
   - Updated `isAllowedHost()` to use proper prefix matching with scheme validation
   - Added `isAllowedScheme()` method with fallback to defaults
   - Fixed external host restrictions to work correctly

4. **Page Processor Integration** (`internal/crawler/page_processor.go`)
   - Updated to pass configured allowed schemes to HTML parser
   - Ensures consistent scheme filtering throughout the crawling pipeline

### 🧪 Comprehensive Testing

- **43 new tests** added across parser and crawler packages
- **HTML Parser Tests**: 13 tests for scheme filtering edge cases
- **Crawler Tests**: 30 tests for URL filtering and host validation
- **Edge Case Coverage**: tel:, mailto:, chrome-extension:, FTP, JavaScript schemes
- **Integration Tests**: Custom schemes, configuration validation, prefix matching

## Before vs After

| Issue | Before ❌ | After ✅ |
|-------|----------|----------|
| Invalid schemes | Stored as crawl errors in database | Filtered at parsing stage |
| External URLs | Processed despite `--follow-external-hosts=false` | Properly blocked by host validation |
| Same-host matching | Limited exact matching only | Flexible prefix-based validation |
| Tel/Mailto links | Created database entries with errors | Silently filtered during parsing |

## Test Results

```
✅ All 13 new HTML parser tests passing
✅ All 30 new crawler URL filtering tests passing  
✅ All existing tests passing (no regressions)
✅ Build successful
```

## Configuration Example

The fix is backward compatible, but users can now customize allowed schemes:

```yaml
# Default behavior (secure)
allowed_schemes: ["https://", "http://"]

# Custom configuration (if needed)
allowed_schemes: ["https://", "http://", "ftp://"]
```

## Fixes

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)