### PR TITLE
fix: Fix Makefile target issues (closes #43)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo '  make <target>'
 	@echo ''
 	@echo 'Targets:'
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ": "} /^## / {sub(/^## /, "", $$1); printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 ## build: Build binary for current platform
 .PHONY: build
@@ -225,7 +225,7 @@ build-windows:
 .PHONY: install
 install:
 	@echo "Installing ${BINARY_NAME}..."
-	go install ${GOFLAGS} ${LDFLAGS} ./${CMD_DIR}
+	go build ${GOFLAGS} ${LDFLAGS} -o $$(go env GOPATH)/bin/${BINARY_NAME} ./${CMD_DIR}
 
 ## uninstall: Remove binary from GOPATH/bin
 .PHONY: uninstall
@@ -238,7 +238,7 @@ uninstall:
 .PHONY: run
 run: build
 	@echo "Running ${BINARY_NAME}..."
-	./${BINARY_NAME} --help
+	./${DIST_DIR}/${BINARY_NAME} --help
 
 ## release-linux: Build Linux binaries for release
 .PHONY: release-linux


### PR DESCRIPTION
## Summary
- Fix make help target AWK script to properly display all targets with descriptions
- Fix make install/uninstall to use correct binary name (linktadoru instead of crawler)  
- Fix make run target to use correct path (./dist/linktadoru)

## Changes Made
1. **make help**: Updated AWK script from `'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $1, $2}'` to `'BEGIN {FS = ": "} /^## / {sub(/^## /, "", $1); printf "  %-15s %s\n", $1, $2}'` to match the `## target: description` comment format
2. **make install/uninstall**: Changed from `go install` to `go build -o $(go env GOPATH)/bin/linktadoru` to ensure correct binary name
3. **make run**: Updated path from `./linktadoru` to `./dist/linktadoru` to match build output location

## Test Plan
- [x] `make help` displays all targets with descriptions
- [x] `make install` creates `linktadoru` binary in GOPATH/bin
- [x] `which linktadoru` finds the installed binary
- [x] `make uninstall` removes `linktadoru` binary
- [x] `make run` executes without path errors
- [x] All tests pass with pre-commit hooks

All targets now work correctly as documented in the Makefile.

🤖 Generated with [Claude Code](https://claude.ai/code)