### PR TITLE
fix: Fix Makefile target issues (closes #43)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ help:
 	@echo '  make <target>'
 	@echo ''
 	@echo 'Targets:'
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ": "} /^## / {sub(/^## /, "", $$1); printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 ## build: Build binary for current platform
 .PHONY: build
@@ -225,7 +225,7 @@ build-windows:
 .PHONY: install
 install:
 	@echo "Installing ${BINARY_NAME}..."
-	go install ${GOFLAGS} ${LDFLAGS} ./${CMD_DIR}
+	go build ${GOFLAGS} ${LDFLAGS} -o $$(go env GOPATH)/bin/${BINARY_NAME} ./${CMD_DIR}
 
 ## uninstall: Remove binary from GOPATH/bin
 .PHONY: uninstall
@@ -238,7 +238,7 @@ uninstall:
 .PHONY: run
 run: build
 	@echo "Running ${BINARY_NAME}..."
-	./${BINARY_NAME} --help
+	./${DIST_DIR}/${BINARY_NAME} --help
 
 ## release-linux: Build Linux binaries for release
 .PHONY: release-linux


### PR DESCRIPTION
- Fix make help target AWK script to properly display all targets
- Fix make install/uninstall to use correct binary name (linktadoru)
- Fix make run target to use correct path (./dist/linktadoru)

All targets now work correctly as documented.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude

## Description

Brief description of changes

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [ ] Tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate)

## Additional Notes

Add any additional notes, concerns, or considerations here.