### PR TITLE
fix: make include/exclude patterns take effect (#46)

### DIFF
--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -183,6 +183,16 @@ func (c *DefaultCrawler) Start(ctx context.Context, seedURLs []string) error {
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	defer c.cancel()
 
+	// Reset rows left in 'processing' by a previous interrupted run back to
+	// 'pending'. No workers are running yet, so every 'processing' row is stale.
+	// This both re-queues interrupted URLs and prevents a stale 'processing' row
+	// from keeping HasQueuedItems() perpetually true, which would otherwise stop
+	// shouldExitOnEmptyQueue from ever firing and hang every worker (issue #46
+	// review follow-up). Passing 0 treats all current 'processing' rows as stale.
+	if err := c.storage.CleanupStaleProcessing(0); err != nil {
+		slog.Error("Failed to reset stale processing rows", "error", err)
+	}
+
 	if len(seedURLs) > 0 {
 		slog.Info("Starting crawler", "seed_urls", len(seedURLs))
 
@@ -370,12 +380,22 @@ func (c *DefaultCrawler) shouldStopWorker(id int) bool {
 	return false
 }
 
-// shouldExitOnEmptyQueue checks if worker should exit when queue is empty
+// shouldExitOnEmptyQueue checks if a worker should exit when GetNextFromQueue
+// returned nothing. It exits only when no crawlable work remains: no 'pending'
+// rows and no 'processing' rows that another worker might still turn into new
+// 'pending' links.
+//
+// This deliberately does NOT key off PagesCrawled. 'discovered' link-graph nodes
+// (issue #46) are not crawlable, so a resume against a database that holds only
+// 'discovered' rows must terminate instead of spinning forever — and a run whose
+// seeds all errored (PagesCrawled == 0) must end rather than hang.
 func (c *DefaultCrawler) shouldExitOnEmptyQueue() bool {
-	c.statsMutex.RLock()
-	defer c.statsMutex.RUnlock()
-
-	return c.stats.PagesCrawled > 0
+	hasItems, err := c.storage.HasQueuedItems()
+	if err != nil {
+		slog.Error("Worker failed to check queued items", "error", err)
+		return false
+	}
+	return !hasItems
 }
 
 // workerSleep applies the configured delay between requests
@@ -393,6 +413,17 @@ func (c *DefaultCrawler) processURLItem(id int, item *URLItem) {
 	// Rate limiting
 	if err := c.rateLimiter.Wait(c.ctx, item.URL); err != nil {
 		slog.Error("Worker rate limiting error", "worker_id", id, "error", err)
+		// A non-cancellation error here (e.g. a malformed URL that fails to parse)
+		// would otherwise leave the row in 'processing' forever and hang the
+		// HasQueuedItems()-based worker exit. Mark it terminal. On context
+		// cancellation we leave the row alone — the run is ending and a later
+		// resume's CleanupStaleProcessing resets it back to 'pending'.
+		if c.ctx.Err() == nil {
+			if serr := c.storage.SavePageError(item.ID, "rate_limit_error", err.Error()); serr != nil {
+				slog.Error("Worker failed to mark rate-limit error", "worker_id", id, "url", item.URL, "error", serr)
+			}
+			c.incrementErrorCount()
+		}
 		return
 	}
 
@@ -439,24 +470,43 @@ func (c *DefaultCrawler) handleProcessingError(id int, item *URLItem, err error)
 
 // handleProcessingResult handles successful page processing results
 func (c *DefaultCrawler) handleProcessingResult(id int, item *URLItem, result *PageResult) {
-	// Save page result
+	// Save links and queue newly discovered URLs BEFORE marking this page
+	// completed. While this runs, item.ID is still 'processing', so
+	// HasQueuedItems() stays true across the whole window — an idle sibling
+	// worker cannot observe an empty queue and exit early before the freshly
+	// discovered links are promoted to 'pending'. Reversing this order would
+	// open a brief pending+processing==0 window on sparse graphs (no data loss,
+	// but lost parallelism).
+	if err := c.storage.SaveLinks(result.Links); err != nil {
+		slog.Error("Worker failed to save links", "worker_id", id, "url", item.URL, "error", err)
+	}
+	c.processNewURLs(id, result.Links, item.URL)
+
+	// Move this page out of 'processing' to a terminal state.
 	if result.Page != nil {
 		if err := c.storage.SavePageResult(item.ID, result.Page); err != nil {
 			slog.Error("Worker failed to save page", "worker_id", id, "url", item.URL, "error", err)
 		} else {
 			c.incrementCrawledCount()
 		}
+	} else {
+		// No page was produced — e.g. a transport/network failure that the
+		// processor encodes in result.Error (Page == nil, no Go error, so it
+		// lands here rather than in handleProcessingError). Mark the row 'error'
+		// so it leaves 'processing'. Otherwise the row would stay 'processing'
+		// forever and the HasQueuedItems()-based worker exit could never fire —
+		// every worker would sleep-loop indefinitely.
+		errType, errMsg := "processing_error", "no page result"
+		if result.Error != nil {
+			errType, errMsg = result.Error.ErrorType, result.Error.ErrorMessage
+		}
+		if err := c.storage.SavePageError(item.ID, errType, errMsg); err != nil {
+			slog.Error("Worker failed to mark page error", "worker_id", id, "url", item.URL, "error", err)
+		}
+		c.incrementErrorCount()
 	}
 
-	// Save all links in batch
-	if err := c.storage.SaveLinks(result.Links); err != nil {
-		slog.Error("Worker failed to save links", "worker_id", id, "url", item.URL, "error", err)
-	}
-
-	// Process new URLs for crawling
-	c.processNewURLs(id, result.Links, item.URL)
-
-	// Save error if any (separate from page processing errors)
+	// Save error details to the crawl_errors table (separate from the pages row).
 	if result.Error != nil {
 		if err := c.storage.SaveError(result.Error); err != nil {
 			slog.Error("Worker failed to save error", "worker_id", id, "url", item.URL, "error", err)
@@ -474,12 +524,15 @@ func (c *DefaultCrawler) handleProcessingResult(id int, item *URLItem, result *P
 func (c *DefaultCrawler) processNewURLs(id int, links []*LinkData, sourceURL string) {
 	var newURLs []string
 	for _, link := range links {
-		if link.LinkType == "internal" && c.shouldCrawlURL(link.TargetURL) {
-			if status, exists := c.storage.GetURLStatus(link.TargetURL); !exists {
-				newURLs = append(newURLs, link.TargetURL)
-			} else {
-				_ = status // URL already tracked
-			}
+		if link.LinkType != "internal" || !c.shouldCrawlURL(link.TargetURL) {
+			continue
+		}
+		// Queue the URL when it is brand new, or when it currently exists only as
+		// a 'discovered' link-graph node (created by SaveLinks). AddToQueue inserts
+		// or promotes it to 'pending'. URLs already pending/processing/completed/
+		// skipped/error are left untouched.
+		if status, exists := c.storage.GetURLStatus(link.TargetURL); !exists || status == "discovered" {
+			newURLs = append(newURLs, link.TargetURL)
 		}
 	}
 

--- a/internal/crawler/issue46_integration_test.go
+++ b/internal/crawler/issue46_integration_test.go
@@ -1,0 +1,279 @@
+package crawler_test
+
+// Integration coverage for issue #46: include_patterns / exclude_patterns must
+// actually prevent non-matching URLs from being crawled. These tests drive the
+// real crawler against an httptest server and a real SQLite store, then assert
+// the resulting page statuses. They live in an external test package to avoid
+// the storage -> crawler import cycle.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/masahif/linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/crawler"
+	"github.com/masahif/linktadoru/internal/storage"
+)
+
+func newStore(t *testing.T) *storage.SQLiteStorage {
+	t.Helper()
+	store, err := storage.NewSQLiteStorage(filepath.Join(t.TempDir(), "issue46.db"))
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func statusOf(t *testing.T, s *storage.SQLiteStorage, url string) (string, bool) {
+	t.Helper()
+	return s.GetURLStatus(url)
+}
+
+// runCrawl serves a seed page that links to the given relative paths, crawls it,
+// and returns the store plus the server base URL for inspection.
+func runCrawl(t *testing.T, cfg *config.CrawlConfig, seedLinks []string) (*storage.SQLiteStorage, string) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		if r.URL.Path == "/" {
+			body := "<html><body>"
+			for _, l := range seedLinks {
+				body += `<a href="` + l + `">link</a>`
+			}
+			body += "</body></html>"
+			_, _ = w.Write([]byte(body))
+			return
+		}
+		// Leaf pages: valid HTML, no further links.
+		_, _ = w.Write([]byte("<html><body>leaf</body></html>"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	cfg.SeedURLs = []string{server.URL}
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := c.Start(ctx, cfg.SeedURLs); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	return store, server.URL
+}
+
+func baseCfg() *config.CrawlConfig {
+	return &config.CrawlConfig{
+		Limit:           10,
+		Concurrency:     1,
+		RequestDelay:    0.001,
+		RequestTimeout:  5 * time.Second,
+		UserAgent:       "LinkTadoru-Test/1.0",
+		IgnoreRobotsTxt: true,
+	}
+}
+
+// Test C (exclude): a URL matching exclude_patterns is recorded as a link-graph
+// node ('discovered') but is never crawled.
+func TestCrawlRespectsExcludePatterns(t *testing.T) {
+	cfg := baseCfg()
+	cfg.ExcludePatterns = []string{"/pickup/"}
+	store, base := runCrawl(t, cfg, []string{"/articles/ok", "/pickup/no"})
+
+	if got, _ := statusOf(t, store, base+"/articles/ok"); got != "completed" {
+		t.Errorf("/articles/ok status = %q, want completed", got)
+	}
+	got, exists := statusOf(t, store, base+"/pickup/no")
+	if !exists {
+		t.Fatal("/pickup/no should exist as a link-graph node")
+	}
+	if got != "discovered" {
+		t.Errorf("/pickup/no status = %q, want discovered (excluded, not crawled)", got)
+	}
+}
+
+// Test C (include): when include_patterns is set, a non-matching URL is recorded
+// as 'discovered' but never crawled.
+func TestCrawlRespectsIncludePatterns(t *testing.T) {
+	cfg := baseCfg()
+	cfg.IncludePatterns = []string{"/articles/"}
+	store, base := runCrawl(t, cfg, []string{"/articles/ok", "/other/no"})
+
+	if got, _ := statusOf(t, store, base+"/articles/ok"); got != "completed" {
+		t.Errorf("/articles/ok status = %q, want completed", got)
+	}
+	got, exists := statusOf(t, store, base+"/other/no")
+	if !exists {
+		t.Fatal("/other/no should exist as a link-graph node")
+	}
+	if got != "discovered" {
+		t.Errorf("/other/no status = %q, want discovered (not in include, not crawled)", got)
+	}
+}
+
+// Regression: a seed whose fetch fails at the network layer must not hang the
+// crawler. The processor returns such failures as result.Error with Page == nil,
+// which must still move the row out of 'processing' to a terminal state — else
+// the HasQueuedItems()-based worker exit never fires (see handleProcessingResult).
+func TestNetworkErrorDoesNotHangAndMarksTerminal(t *testing.T) {
+	// Stand up a server, capture its URL, then close it so the address refuses
+	// connections — a deterministic network-layer failure.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := server.URL
+	server.Close()
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{deadURL}
+	cfg.RequestTimeout = 2 * time.Second
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Start(context.Background(), cfg.SeedURLs) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("crawler hung on a network-errored seed (row stuck in 'processing')")
+	}
+
+	status, exists := statusOf(t, store, deadURL)
+	if !exists {
+		t.Fatal("seed row should exist")
+	}
+	if status == "processing" || status == "pending" {
+		t.Errorf("seed status = %q, want a terminal state (not stuck in the queue)", status)
+	}
+	if status != "error" {
+		t.Errorf("seed status = %q, want error", status)
+	}
+}
+
+// Regression: a malformed seed URL (one that fails url.Parse in the rate
+// limiter) must be driven to a terminal state, not left in 'processing' where it
+// would hang the HasQueuedItems()-based worker exit.
+func TestMalformedURLDoesNotHangAndMarksTerminal(t *testing.T) {
+	// A control character makes net/url.Parse fail.
+	badURL := "http://example.com/\x7f"
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{badURL}
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Start(context.Background(), cfg.SeedURLs) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("crawler hung on a malformed seed URL (row stuck in 'processing')")
+	}
+
+	if got, _ := statusOf(t, store, badURL); got != "error" {
+		t.Errorf("malformed seed status = %q, want error (terminal)", got)
+	}
+}
+
+// Regression: a database carrying a stale 'processing' row from a previously
+// interrupted/crashed run must not hang a resumed crawl. Start() resets stale
+// 'processing' rows to 'pending'; without that, HasQueuedItems() would count the
+// stale row forever and workers would never exit.
+func TestStaleProcessingRowDoesNotHangOnResume(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := server.URL
+	server.Close()
+
+	store := newStore(t)
+	// Simulate a previous run that claimed the URL (pending -> processing) and
+	// then crashed before completing it.
+	if err := store.AddToQueue([]string{deadURL}); err != nil {
+		t.Fatalf("AddToQueue: %v", err)
+	}
+	if item, err := store.GetNextFromQueue(); err != nil || item == nil {
+		t.Fatalf("GetNextFromQueue (claim): item=%v err=%v", item, err)
+	}
+	if got, _ := statusOf(t, store, deadURL); got != "processing" {
+		t.Fatalf("precondition status = %q, want processing", got)
+	}
+
+	cfg := baseCfg()
+	cfg.RequestTimeout = 2 * time.Second
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Start(context.Background(), nil) }() // resume, no seeds
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("crawler hung on a stale 'processing' row at resume")
+	}
+
+	// The stale row must have been reset and then driven to a terminal state.
+	if got, _ := statusOf(t, store, deadURL); got == "processing" || got == "pending" {
+		t.Errorf("stale row status = %q, want a terminal state", got)
+	}
+}
+
+// Test D: a database that holds only 'discovered' nodes (e.g. a seedless resume)
+// must not spin forever — workers must exit promptly.
+func TestSeedlessResumeWithOnlyDiscoveredDoesNotHang(t *testing.T) {
+	store := newStore(t)
+	if err := store.SaveLinks([]*crawler.LinkData{
+		{SourceURL: "https://example.com/a", TargetURL: "https://example.com/b", LinkType: "internal"},
+	}); err != nil {
+		t.Fatalf("SaveLinks: %v", err)
+	}
+
+	cfg := baseCfg()
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Start(context.Background(), nil) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start returned error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("crawler did not exit on a discovered-only database (infinite sleep)")
+	}
+}

--- a/internal/storage/issue46_test.go
+++ b/internal/storage/issue46_test.go
@@ -1,0 +1,319 @@
+package storage
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/masahif/linktadoru/internal/crawler"
+)
+
+// newTempStorage creates an isolated SQLite storage backed by a temp file.
+func newTempStorage(t *testing.T) *SQLiteStorage {
+	t.Helper()
+	dbFile := filepath.Join(t.TempDir(), "issue46.db")
+	store, err := NewSQLiteStorage(dbFile)
+	if err != nil {
+		t.Fatalf("failed to create storage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func mustStatus(t *testing.T, s *SQLiteStorage, url string) string {
+	t.Helper()
+	status, exists := s.GetURLStatus(url)
+	if !exists {
+		t.Fatalf("expected URL %q to exist", url)
+	}
+	return status
+}
+
+// Test A: saving links creates link-graph nodes as 'discovered', and those nodes
+// are NOT handed out by GetNextFromQueue (i.e. they are not queued for crawling).
+func TestSaveLinksCreatesDiscoveredNotQueued(t *testing.T) {
+	store := newTempStorage(t)
+
+	source := "https://example.com/from"
+	target := "https://example.com/to"
+	if err := store.SaveLinks([]*crawler.LinkData{
+		{SourceURL: source, TargetURL: target, LinkType: "internal"},
+	}); err != nil {
+		t.Fatalf("SaveLinks failed: %v", err)
+	}
+
+	if got := mustStatus(t, store, source); got != "discovered" {
+		t.Errorf("source status = %q, want discovered", got)
+	}
+	if got := mustStatus(t, store, target); got != "discovered" {
+		t.Errorf("target status = %q, want discovered", got)
+	}
+
+	// Nothing should be crawlable: GetNextFromQueue only returns 'pending' rows.
+	item, err := store.GetNextFromQueue()
+	if err != nil {
+		t.Fatalf("GetNextFromQueue failed: %v", err)
+	}
+	if item != nil {
+		t.Errorf("expected empty queue, got %+v", item)
+	}
+}
+
+// Test A (singular): SaveLink also creates its source/target as 'discovered'
+// link-graph nodes that are not queued. SaveLink goes through getOrCreatePageID,
+// a separate path from SaveLinks/saveLinksBatch (issue #46).
+func TestSaveLinkCreatesDiscoveredNotQueued(t *testing.T) {
+	store := newTempStorage(t)
+
+	source := "https://example.com/single-from"
+	target := "https://example.com/single-to"
+	if err := store.SaveLink(&crawler.LinkData{
+		SourceURL: source, TargetURL: target, LinkType: "internal",
+	}); err != nil {
+		t.Fatalf("SaveLink failed: %v", err)
+	}
+
+	if got := mustStatus(t, store, source); got != "discovered" {
+		t.Errorf("source status = %q, want discovered", got)
+	}
+	if got := mustStatus(t, store, target); got != "discovered" {
+		t.Errorf("target status = %q, want discovered", got)
+	}
+
+	item, err := store.GetNextFromQueue()
+	if err != nil {
+		t.Fatalf("GetNextFromQueue failed: %v", err)
+	}
+	if item != nil {
+		t.Errorf("expected empty queue, got %+v", item)
+	}
+}
+
+// Test B: AddToQueue inserts new URLs as 'pending', promotes 'discovered' nodes
+// to 'pending', and leaves every terminal/in-flight status untouched.
+func TestAddToQueuePromotesOnlyDiscovered(t *testing.T) {
+	t.Run("new URL becomes pending", func(t *testing.T) {
+		store := newTempStorage(t)
+		url := "https://example.com/new"
+		if err := store.AddToQueue([]string{url}); err != nil {
+			t.Fatalf("AddToQueue: %v", err)
+		}
+		if got := mustStatus(t, store, url); got != "pending" {
+			t.Errorf("status = %q, want pending", got)
+		}
+	})
+
+	t.Run("discovered URL is promoted to pending", func(t *testing.T) {
+		store := newTempStorage(t)
+		url := "https://example.com/disc"
+		if err := store.SaveLinks([]*crawler.LinkData{
+			{SourceURL: "https://example.com/src", TargetURL: url, LinkType: "internal"},
+		}); err != nil {
+			t.Fatalf("SaveLinks: %v", err)
+		}
+		if got := mustStatus(t, store, url); got != "discovered" {
+			t.Fatalf("precondition status = %q, want discovered", got)
+		}
+		if err := store.AddToQueue([]string{url}); err != nil {
+			t.Fatalf("AddToQueue: %v", err)
+		}
+		if got := mustStatus(t, store, url); got != "pending" {
+			t.Errorf("status = %q, want pending", got)
+		}
+	})
+
+	// Each terminal/in-flight status must survive a re-queue attempt unchanged.
+	for _, tc := range []struct {
+		name   string
+		setup  func(t *testing.T, s *SQLiteStorage, id int)
+		expect string
+	}{
+		{
+			name:   "completed",
+			setup:  func(t *testing.T, s *SQLiteStorage, id int) { mustSaveResult(t, s, id) },
+			expect: "completed",
+		},
+		{
+			name:   "processing",
+			setup:  func(t *testing.T, s *SQLiteStorage, id int) {}, // GetNextFromQueue already set it
+			expect: "processing",
+		},
+		{
+			name: "skipped",
+			setup: func(t *testing.T, s *SQLiteStorage, id int) {
+				if err := s.SavePageSkipped(id, "robots", "blocked"); err != nil {
+					t.Fatalf("SavePageSkipped: %v", err)
+				}
+			},
+			expect: "skipped",
+		},
+		{
+			name: "error",
+			setup: func(t *testing.T, s *SQLiteStorage, id int) {
+				if err := s.SavePageError(id, "network_timeout", "boom"); err != nil {
+					t.Fatalf("SavePageError: %v", err)
+				}
+			},
+			expect: "error",
+		},
+	} {
+		t.Run(tc.name+" is left untouched", func(t *testing.T) {
+			store := newTempStorage(t)
+			url := "https://example.com/" + tc.name
+			if err := store.AddToQueue([]string{url}); err != nil {
+				t.Fatalf("AddToQueue: %v", err)
+			}
+			item, err := store.GetNextFromQueue() // pending -> processing
+			if err != nil || item == nil {
+				t.Fatalf("GetNextFromQueue: item=%v err=%v", item, err)
+			}
+			tc.setup(t, store, item.ID)
+			if got := mustStatus(t, store, url); got != tc.expect {
+				t.Fatalf("precondition status = %q, want %q", got, tc.expect)
+			}
+
+			// Re-queueing must NOT change a non-discovered row.
+			if err := store.AddToQueue([]string{url}); err != nil {
+				t.Fatalf("AddToQueue (re): %v", err)
+			}
+			if got := mustStatus(t, store, url); got != tc.expect {
+				t.Errorf("status after re-queue = %q, want %q (unchanged)", got, tc.expect)
+			}
+		})
+	}
+}
+
+// CleanupStaleProcessing must reset every 'processing' row — including one whose
+// processing_started_at is NULL. `NULL < ?` is never true in SQL, so without the
+// explicit IS NULL clause such a row would survive and keep HasQueuedItems() true
+// forever, re-introducing the worker hang (review finding).
+func TestCleanupStaleProcessingResetsNullAndOldTimestamps(t *testing.T) {
+	store := newTempStorage(t)
+
+	// Anomalous: 'processing' with a NULL start time.
+	if _, err := store.db.Exec(
+		"INSERT INTO pages (url, status, processing_started_at) VALUES ('https://example.com/null-ts', 'processing', NULL)",
+	); err != nil {
+		t.Fatalf("seed null-ts: %v", err)
+	}
+	// Normal stale: 'processing' claimed an hour ago.
+	hourAgo := time.Now().Add(-time.Hour)
+	if _, err := store.db.Exec(
+		"INSERT INTO pages (url, status, added_at, processing_started_at) VALUES ('https://example.com/old-ts', 'processing', ?, ?)",
+		hourAgo, hourAgo,
+	); err != nil {
+		t.Fatalf("seed old-ts: %v", err)
+	}
+
+	if err := store.CleanupStaleProcessing(0); err != nil {
+		t.Fatalf("CleanupStaleProcessing: %v", err)
+	}
+
+	for _, u := range []string{"https://example.com/null-ts", "https://example.com/old-ts"} {
+		if got := mustStatus(t, store, u); got != "pending" {
+			t.Errorf("%s status = %q, want pending (reset)", u, got)
+		}
+	}
+}
+
+func mustSaveResult(t *testing.T, s *SQLiteStorage, id int) {
+	t.Helper()
+	if err := s.SavePageResult(id, &crawler.PageData{
+		StatusCode:  200,
+		HTTPHeaders: map[string]string{"content-type": "text/html"},
+	}); err != nil {
+		t.Fatalf("SavePageResult: %v", err)
+	}
+}
+
+// Migration test: a database created before issue #46 (CHECK without 'discovered')
+// is rebuilt by InitSchema so the new status is accepted and existing rows survive.
+func TestMigratePagesAddDiscovered(t *testing.T) {
+	dbFile := filepath.Join(t.TempDir(), "legacy.db")
+
+	// Build a legacy database by stripping 'discovered' from the current schema.
+	legacySchema := strings.Replace(schemaSQL, ", 'discovered'", "", 1)
+	if legacySchema == schemaSQL {
+		t.Fatal("failed to derive legacy schema; marker not found")
+	}
+
+	legacy := &SQLiteStorage{}
+	{
+		store, err := NewSQLiteStorage(dbFile)
+		if err != nil {
+			t.Fatalf("open: %v", err)
+		}
+		// Replace the up-to-date pages table with the legacy one.
+		if _, err := store.db.Exec("DROP VIEW IF EXISTS links; DROP VIEW IF EXISTS completed_pages; DROP VIEW IF EXISTS queue_status; DROP TABLE IF EXISTS link_relations; DROP TABLE pages;"); err != nil {
+			t.Fatalf("reset: %v", err)
+		}
+		if _, err := store.db.Exec(legacySchema); err != nil {
+			t.Fatalf("legacy schema: %v", err)
+		}
+		// Seed legacy rows + a link relation so views have real data to read back.
+		if _, err := store.db.Exec(`
+			INSERT INTO pages (id, url, status, response_http_headers) VALUES
+				(1, 'https://example.com/legacy', 'completed', '{"content-type":"text/html"}'),
+				(2, 'https://example.com/target', 'pending', NULL);
+			INSERT INTO link_relations (source_page_id, target_page_id, link_type)
+				VALUES (1, 2, 'internal');
+		`); err != nil {
+			t.Fatalf("seed rows: %v", err)
+		}
+		if _, err := store.db.Exec("INSERT INTO pages (url, status) VALUES ('https://example.com/x', 'discovered')"); err == nil {
+			t.Fatal("legacy schema unexpectedly accepted 'discovered'")
+		}
+		legacy = store
+	}
+
+	// Run the migration (and schema recreate) on the legacy DB.
+	if err := legacy.InitSchema(); err != nil {
+		t.Fatalf("InitSchema (migration) failed: %v", err)
+	}
+
+	// Existing data preserved.
+	if got := mustStatus(t, legacy, "https://example.com/legacy"); got != "completed" {
+		t.Errorf("legacy row status = %q, want completed", got)
+	}
+	// 'discovered' now accepted.
+	if _, err := legacy.db.Exec("INSERT INTO pages (url, status) VALUES ('https://example.com/now', 'discovered')"); err != nil {
+		t.Errorf("post-migration insert of 'discovered' failed: %v", err)
+	}
+
+	// Views recreated and readable against the preserved data.
+	for _, view := range []string{"queue_status", "completed_pages", "links"} {
+		if _, err := legacy.db.Exec("SELECT count(*) FROM " + view); err != nil {
+			t.Errorf("view %q not usable after migration: %v", view, err)
+		}
+	}
+	// completed_pages must expose the preserved completed row.
+	var completed int
+	if err := legacy.db.QueryRow(
+		"SELECT count(*) FROM completed_pages WHERE url = 'https://example.com/legacy'",
+	).Scan(&completed); err != nil || completed != 1 {
+		t.Errorf("completed_pages missing preserved row: count=%d err=%v", completed, err)
+	}
+	// links view must resolve the preserved relation back to URLs.
+	var src, tgt string
+	if err := legacy.db.QueryRow(
+		"SELECT source_url, target_url FROM links LIMIT 1",
+	).Scan(&src, &tgt); err != nil {
+		t.Errorf("links view unreadable after migration: %v", err)
+	} else if src != "https://example.com/legacy" || tgt != "https://example.com/target" {
+		t.Errorf("links view rows = (%q -> %q), want legacy -> target", src, tgt)
+	}
+
+	// Index restored on the rebuilt table.
+	var idx int
+	if err := legacy.db.QueryRow(
+		"SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_pages_status'",
+	).Scan(&idx); err != nil || idx != 1 {
+		t.Errorf("idx_pages_status not restored: count=%d err=%v", idx, err)
+	}
+	// Foreign keys re-enabled after the migration.
+	var fk int
+	if err := legacy.db.QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil || fk != 1 {
+		t.Errorf("foreign_keys not restored to ON: fk=%d err=%v", fk, err)
+	}
+}

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -1,0 +1,102 @@
+// Package storage — schema migrations.
+//
+// This file rebuilds an existing `pages` table whose CHECK constraint predates
+// the 'discovered' status added for issue #46. SQLite cannot ALTER a CHECK
+// constraint in place, so the table is rebuilt with the standard rename/copy
+// procedure. The migration is a no-op on a fresh database (the table does not
+// exist yet) and on a database already carrying the 'discovered' status.
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// pagesBaseColumns are the non-generated columns of the pages table, in a stable
+// order. Generated columns (content_type, content_length, last_modified, server,
+// content_encoding, x_cache) are derived and must NOT be copied explicitly.
+const pagesBaseColumns = "id, url, status, added_at, processing_started_at, " +
+	"status_code, title, meta_description, meta_robots, canonical_url, " +
+	"content_hash, ttfb_ms, download_time_ms, response_size_bytes, " +
+	"response_http_headers, crawled_at, retry_count, last_error_type, " +
+	"last_error_message"
+
+// migratePagesAddDiscovered widens the pages.status CHECK constraint to include
+// 'discovered' on databases created before issue #46. It detects the need for
+// migration from the stored table DDL, then rebuilds the table preserving all
+// rows and ids. Indexes and views dropped by the rebuild are recreated by the
+// subsequent schemaSQL run in InitSchema.
+//
+// Scope: this migration is guaranteed only for databases created with the
+// current released pages schema (status CHECK ... 'skipped', 'error'). It is
+// intentionally conservative — it copies the fixed set of base columns
+// (pagesBaseColumns) and locates the CHECK list by its exact text. Against an
+// older/foreign schema where that text is absent, it ABORTS with an error
+// rather than risk a lossy rebuild; the caller surfaces the error and the
+// database is left untouched. Broader cross-version migration (dynamic column
+// intersection, status normalisation) is out of scope here.
+func (s *SQLiteStorage) migratePagesAddDiscovered() error {
+	var ddl string
+	err := s.db.QueryRow(
+		"SELECT sql FROM sqlite_master WHERE type='table' AND name='pages'",
+	).Scan(&ddl)
+	if err == sql.ErrNoRows {
+		return nil // fresh database — schemaSQL will create the up-to-date table
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read pages table definition: %w", err)
+	}
+	if strings.Contains(ddl, "'discovered'") {
+		return nil // already migrated
+	}
+
+	// Build the new table DDL from the existing one so any prior columns are
+	// preserved verbatim; only the table name and the CHECK list change.
+	paren := strings.Index(ddl, "(")
+	if paren < 0 {
+		return fmt.Errorf("unexpected pages table definition: %q", ddl)
+	}
+	newDDL := "CREATE TABLE pages_new " + ddl[paren:]
+	widened := strings.Replace(newDDL,
+		"'skipped', 'error')", "'skipped', 'error', 'discovered')", 1)
+	if widened == newDDL {
+		return fmt.Errorf("could not locate pages status CHECK constraint to widen; aborting migration")
+	}
+	newDDL = widened
+
+	// Foreign keys must be off while the referenced table is rebuilt; this PRAGMA
+	// is a no-op inside a transaction, so toggle it around the transaction.
+	if _, err := s.db.Exec("PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("failed to disable foreign keys: %w", err)
+	}
+	defer func() { _, _ = s.db.Exec("PRAGMA foreign_keys = ON") }()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("failed to begin migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmts := []string{
+		// Drop views that reference pages; schemaSQL recreates them afterwards.
+		"DROP VIEW IF EXISTS links",
+		"DROP VIEW IF EXISTS completed_pages",
+		"DROP VIEW IF EXISTS queue_status",
+		newDDL,
+		fmt.Sprintf("INSERT INTO pages_new (%s) SELECT %s FROM pages",
+			pagesBaseColumns, pagesBaseColumns),
+		"DROP TABLE pages",
+		"ALTER TABLE pages_new RENAME TO pages",
+	}
+	for _, stmt := range stmts {
+		if _, err := tx.Exec(stmt); err != nil {
+			return fmt.Errorf("migration step failed (%s): %w", stmt, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit pages migration: %w", err)
+	}
+	return nil
+}

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -2,11 +2,16 @@ package storage
 
 const schemaSQL = `
 -- Pages table now serves as both queue and results storage
--- status column manages the lifecycle: pending -> processing -> completed/skipped/error
+-- status column manages the lifecycle:
+--   discovered -> pending -> processing -> completed/skipped/error
+-- 'discovered' marks a page that exists only as a link-graph node (the target of
+-- a saved link) and has NOT been selected for crawling. Only 'pending' rows are
+-- picked up by GetNextFromQueue, so include/exclude filtering takes effect when a
+-- discovered node is promoted to 'pending' (see AddToQueue / processNewURLs).
 CREATE TABLE IF NOT EXISTS pages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     url TEXT UNIQUE NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error')),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error', 'discovered')),
     
     -- Queue-related fields
     added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -60,7 +60,14 @@ func (s *SQLiteStorage) InitSchema() error {
 		}
 	}
 
-	// Create schema
+	// Migrate an existing pages table whose CHECK constraint predates the
+	// 'discovered' status (see migratePagesAddDiscovered). No-op on a fresh DB.
+	if err := s.migratePagesAddDiscovered(); err != nil {
+		return fmt.Errorf("failed to migrate pages table: %w", err)
+	}
+
+	// Create schema (idempotent). After a migration this also recreates the
+	// indexes and views that the table rebuild dropped.
 	if _, err := s.db.Exec(schemaSQL); err != nil {
 		return fmt.Errorf("failed to create schema: %w", err)
 	}
@@ -73,8 +80,22 @@ func (s *SQLiteStorage) Close() error {
 	return s.db.Close()
 }
 
-// AddToQueue adds URLs to the queue (pages table with status='pending')
-// Uses INSERT OR IGNORE to prevent duplicates
+// AddToQueue queues URLs for crawling by setting their status to 'pending'.
+//
+// It is an upsert that owns the "promote to pending" responsibility:
+//   - a brand new URL is inserted with status='pending'
+//   - a URL already known only as a link-graph node ('discovered') is promoted
+//     to 'pending' so it gets crawled
+//   - URLs already 'pending'/'processing'/'completed'/'skipped'/'error' are left
+//     untouched (no re-queue; retries are handled by RequeueErrorPages)
+//
+// Callers are expected to have applied include/exclude filtering before calling
+// this; that is what makes the patterns take effect (see processNewURLs).
+//
+// On promotion, added_at is refreshed to the enqueue time so the URL joins the
+// tail of the added_at-ordered queue. This is intentional: it preserves
+// breadth-first crawl order (a node discovered earlier but only now selected for
+// crawling is queued at the moment of selection, not its discovery time).
 func (s *SQLiteStorage) AddToQueue(urls []string) error {
 	if len(urls) == 0 {
 		return nil
@@ -87,8 +108,12 @@ func (s *SQLiteStorage) AddToQueue(urls []string) error {
 	defer func() { _ = tx.Rollback() }()
 
 	stmt, err := tx.Prepare(`
-		INSERT OR IGNORE INTO pages (url, status, added_at) 
+		INSERT INTO pages (url, status, added_at)
 		VALUES (?, 'pending', ?)
+		ON CONFLICT(url) DO UPDATE SET
+			status = 'pending',
+			added_at = excluded.added_at
+		WHERE pages.status = 'discovered'
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare statement: %w", err)
@@ -321,9 +346,11 @@ func (s *SQLiteStorage) saveLinksBatch(links []*crawler.LinkData) error {
 			return fmt.Errorf("failed to query page ID for %s: %w", url, err)
 		}
 
-		// Create page if it doesn't exist
+		// Create page if it doesn't exist. New nodes are 'discovered' (link-graph
+		// only), NOT 'pending' — otherwise every discovered link would be queued
+		// for crawling, bypassing include/exclude filtering (issue #46).
 		result, err := tx.Exec(
-			"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'pending', ?)",
+			"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'discovered', ?)",
 			url, time.Now(),
 		)
 		if err != nil {
@@ -525,15 +552,20 @@ func (s *SQLiteStorage) GetProcessingItems() ([]crawler.URLItem, error) {
 	return items, nil
 }
 
-// CleanupStaleProcessing resets processing items that have been stuck
+// CleanupStaleProcessing resets processing items that have been stuck back to
+// 'pending'. A row with a NULL processing_started_at is always reset: `NULL < ?`
+// is never true in SQL, so without the explicit IS NULL clause such a row would
+// survive cleanup and keep HasQueuedItems() perpetually true, hanging the
+// crawler. The timestamp should never be NULL on the normal path, but the
+// invariant is cheap to enforce here.
 func (s *SQLiteStorage) CleanupStaleProcessing(timeout time.Duration) error {
 	cutoff := time.Now().Add(-timeout)
 
 	_, err := s.db.Exec(`
-		UPDATE pages 
-		SET status = 'pending', processing_started_at = NULL 
-		WHERE status = 'processing' 
-		AND processing_started_at < ?
+		UPDATE pages
+		SET status = 'pending', processing_started_at = NULL
+		WHERE status = 'processing'
+		AND (processing_started_at < ? OR processing_started_at IS NULL)
 	`, cutoff)
 
 	if err != nil {
@@ -592,9 +624,10 @@ func (s *SQLiteStorage) getOrCreatePageID(url string) (int, error) {
 		return 0, fmt.Errorf("failed to query page ID: %w", err)
 	}
 
-	// Page doesn't exist, create it with 'queued' status
+	// Page doesn't exist, create it as a 'discovered' link-graph node (not
+	// 'pending') so it is not crawled unless AddToQueue promotes it (issue #46).
 	result, err := s.db.Exec(
-		"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'pending', ?)",
+		"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'discovered', ?)",
 		url, time.Now(),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #46 — `include_patterns` / `exclude_patterns` had no effect during crawling.

**Root cause:** the `pages` table doubles as the crawl queue (`status='pending'` rows handed out by `GetNextFromQueue`) **and** the link graph. `saveLinksBatch` / `getOrCreatePageID` inserted every discovered URL as `pending`, so the `shouldCrawlURL` filter (only applied in `processNewURLs`) was bypassed — every discovered link was queued and crawled regardless of the patterns.

**Fix:** introduce a `discovered` status for link-graph-only nodes. `GetNextFromQueue` still hands out `pending` only; `AddToQueue` is the single place that promotes a filtered URL `discovered → pending`. Include/exclude now governs what gets crawled, while the link graph is fully preserved.

## Changes

**storage**
- `schema.go`: add `discovered` to the `pages.status` CHECK constraint
- `migrate.go` (new): rebuild an existing `pages` table whose CHECK predates `discovered` (SQLite can't `ALTER` a CHECK); FK off + single transaction, views/indexes restored, rows/ids preserved; conservative — aborts (DB untouched) on an out-of-scope schema
- `sqlite.go`: `saveLinksBatch` / `getOrCreatePageID` create `discovered` nodes; `AddToQueue` upserts (`discovered → pending`, other states untouched); `CleanupStaleProcessing` also resets `NULL processing_started_at` rows

**crawler**
- `processNewURLs` promotes `discovered` nodes
- `shouldExitOnEmptyQueue` keys off `HasQueuedItems()` (pending+processing) so a discovered-only / all-errored run terminates
- queue links **before** marking a page completed (keep the row `processing` across the promotion window)
- move rows out of `processing` on network / rate-limiter errors, and reset stale `processing` rows at `Start` (crash resume) — no terminal hang

## Testing

- Unit/integration: discovered-not-queued (batch & single path), `AddToQueue` promotion semantics, include/exclude end-to-end, in-place migration (data/views/indexes/FK preserved), and no-hang regressions (network error, malformed URL, stale processing, discovered-only)
- `go build / vet / test -race ./...` all green
- Verified end-to-end against a live local server with the real binary: old build crawls `/pickup/` despite `exclude`; this build records it as `discovered` (not crawled) while keeping it in the link graph; in-place migration of an old-schema DB succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
