### PR TITLE
fix: project audit — revive retries, bound response reads, honor Crawl-delay, fix doc drift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to LinkTadoru are documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Fixed
+- Retry mechanism never fired: the retryable-error filter matched error types
+  that were never written. Transient `network_error` failures are now retried
+  (up to 3 times); deterministic failures are not.
+- Invalid `include_patterns` / `exclude_patterns` regexes were silently
+  ignored. They are now validated at startup and abort the run with a clear
+  error message.
+- URL fragments (`#section`) are stripped from discovered links, so anchors on
+  the same page no longer produce duplicate rows and duplicate crawls.
+- Timestamps are stored in a fixed-width UTC format so queue ordering and
+  stale-processing cleanup are independent of local timezone and DST changes.
+- Documentation drift: `ignore_robots` → `ignore_robots_txt` (config key),
+  `--ignore-robots` → `--ignore-robots-txt` (CLI flag), and the pages status
+  lifecycle in the technical specification now matches the implementation
+  (`discovered` → `pending` → `processing` → `completed`/`skipped`/`error`).
+
+### Added
+- `max_response_size` config / `--max-response-size` flag: response bodies are
+  capped (default 10 MiB) so oversized responses cannot exhaust memory;
+  oversized pages are recorded as `response_too_large` errors.
+- robots.txt `Crawl-delay` is now honored when it is slower than the
+  configured request delay.
+- Graceful shutdown on SIGINT/SIGTERM: in-flight state is persisted and the
+  database is closed cleanly.
+- Warnings are logged when robots.txt cannot be fetched (fail-open) or
+  contains a malformed `Crawl-delay`.
+- Logging configuration keys documented in `linktadoru.yml.example`.
+- Dependabot configuration for Go module and GitHub Actions updates.
+
+### Removed
+- Dead code: unused `GetProcessingItems` storage method.
+
+## [0.8.7] - 2026-06-27
+
+### Fixed
+- `include_patterns` / `exclude_patterns` had no effect (#46): discovered
+  links were queued unconditionally, bypassing the URL filters. Link-graph
+  nodes are now recorded as `discovered` and only promoted to the crawl queue
+  when they pass the filters. Existing databases are migrated in place.
+- Crawler no longer hangs on network-errored seeds, malformed URLs, or stale
+  `processing` rows left by an interrupted run.
+- Fixed Makefile target issues (#43).
+
+## [0.8.6] - 2025-08-10
+
+### Fixed
+- URL filtering and same-host validation logic (#38).
+
+## [0.8.0 – 0.8.5] - 2025-08-07 – 2025-08-10
+
+- Authentication support (basic / bearer / API key), custom HTTP headers,
+  logging with rotation, CI/release pipeline hardening, and assorted fixes.
+
+## [0.5.0 – 0.7.2] - 2025-08-01 – 2025-08-07
+
+- Initial public iterations: concurrent queue-based crawler with SQLite
+  storage, robots.txt support, URL filtering, and link-graph analysis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Fixed
-- Retry mechanism never fired: the retryable-error filter matched error types
-  that were never written. Transient `network_error` failures are now retried
-  (up to 3 times); deterministic failures are not.
+- Retry mechanism never fired — two independent bugs: the retryable-error
+  filter matched error types that were never written, and the retry phase
+  itself was unreachable (the last exiting worker cancelled the crawl
+  context). Transient `network_error` failures now get one retry pass per
+  run, bounded by a total of 3 attempts across runs; deterministic failures
+  are not retried.
 - Invalid `include_patterns` / `exclude_patterns` regexes were silently
   ignored. They are now validated at startup and abort the run with a clear
   error message.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for considering contributing to LinkTadoru! It's people lik
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [LinkTadoru Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+Please be respectful and constructive in all project interactions — issues, pull requests, and reviews.
 
 ## How Can I Contribute?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,7 +76,7 @@ LinkTadoruは以下の階層設定優先順位に従います：
 concurrency: 2
 request_delay: 0.1           # 秒
 user_agent: "LinkTadoru/1.0"
-ignore_robots: false
+ignore_robots_txt: false
 database_path: "./linktadoru.db"
 limit: 0                    # 0 = 無制限
 
@@ -107,7 +107,7 @@ headers:
 # 基本設定
 export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.5
-export LT_IGNORE_ROBOTS=true
+export LT_IGNORE_ROBOTS_TXT=true
 
 # 階層設定（アンダースコアを使用）
 export LT_AUTH_TYPE=basic

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ LinkTadoru follows a hierarchical configuration priority:
 concurrency: 2
 request_delay: 0.1           # seconds
 user_agent: "LinkTadoru/1.0"
-ignore_robots: false
+ignore_robots_txt: false
 database_path: "./linktadoru.db"
 limit: 0                    # 0 = unlimited
 
@@ -107,7 +107,7 @@ All configuration can be set via environment variables with `LT_` prefix:
 # Basic settings
 export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.5
-export LT_IGNORE_ROBOTS=true
+export LT_IGNORE_ROBOTS_TXT=true
 
 # Hierarchical settings (using underscores)
 export LT_AUTH_TYPE=basic

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -22,7 +22,8 @@ func main() {
 
 	// Cancel the crawl context on SIGINT/SIGTERM so workers stop cleanly and
 	// the database is closed, instead of the process being killed mid-write.
-	// A second signal falls through to the default handler (immediate exit).
+	// Signals stay captured until stop() runs (after ExecuteContext returns),
+	// so repeated Ctrl-C during shutdown is absorbed rather than fatal.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/cmd/crawler/main.go
+++ b/cmd/crawler/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/masahif/linktadoru/internal/cmd"
 )
@@ -17,7 +20,13 @@ func main() {
 	// Set version information
 	cmd.SetVersionInfo(Version, BuildTime)
 
-	if err := cmd.Execute(); err != nil {
+	// Cancel the crawl context on SIGINT/SIGTERM so workers stop cleanly and
+	// the database is closed, instead of the process being killed mid-write.
+	// A second signal falls through to the default handler (immediate exit).
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/docs/basic-usage.ja.md
+++ b/docs/basic-usage.ja.md
@@ -30,7 +30,7 @@ concurrency: 3
 request_delay: 1s
 request_timeout: 15s
 user_agent: "MyBot/1.0"
-ignore_robots: false
+ignore_robots_txt: false
 limit: 50
 database_path: "./mysite-crawl.db"
 
@@ -79,7 +79,7 @@ LinkTadoruは既存のデータベースから自動的に再開します：
 
 ```bash
 ./linktadoru \
-  --ignore-robots \
+  --ignore-robots-txt \
   --concurrency 20 \
   --delay 500ms \
   https://httpbin.org
@@ -152,7 +152,7 @@ limit: 0  # 無制限
 concurrency: 2
 request_delay: 5s
 request_timeout: 30s
-ignore_robots: false
+ignore_robots_txt: false
 user_agent: "PoliteBot/1.0"
 ```
 
@@ -162,7 +162,7 @@ user_agent: "PoliteBot/1.0"
 
 1. **データベースロック**: 他のインスタンスを停止するか、異なるデータベースファイルを使用
 2. **エラーが多すぎる**: タイムアウトを増やすか、並行性を減らす
-3. **robots.txtによるブロック**: `--ignore-robots`フラグを使用（責任を持って使用）
+3. **robots.txtによるブロック**: `--ignore-robots-txt`フラグを使用（責任を持って使用）
 4. **メモリ使用量**: 大規模サイトでは並行性を減らす
 
 ### 進行状況の監視

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -30,7 +30,7 @@ concurrency: 3
 request_delay: 1s
 request_timeout: 15s
 user_agent: "MyBot/1.0"
-ignore_robots: false
+ignore_robots_txt: false
 limit: 50
 database_path: "./mysite-crawl.db"
 
@@ -79,7 +79,7 @@ LinkTadoru automatically resumes from existing database:
 
 ```bash
 ./linktadoru \
-  --ignore-robots \
+  --ignore-robots-txt \
   --concurrency 20 \
   --delay 500ms \
   https://httpbin.org
@@ -152,7 +152,7 @@ limit: 0  # unlimited
 concurrency: 2
 request_delay: 5s
 request_timeout: 30s
-ignore_robots: false
+ignore_robots_txt: false
 user_agent: "PoliteBot/1.0"
 ```
 
@@ -162,7 +162,7 @@ user_agent: "PoliteBot/1.0"
 
 1. **Database locked**: Stop other instances or use different database file
 2. **Too many errors**: Increase timeout or reduce concurrency
-3. **Blocked by robots.txt**: Use `--ignore-robots` flag (use responsibly)
+3. **Blocked by robots.txt**: Use `--ignore-robots-txt` flag (use responsibly)
 4. **Memory usage**: Reduce concurrency for large sites
 
 ### Monitoring Progress

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ Flags:
       --exclude-patterns strings   Regex patterns for URLs to exclude
   -H, --header strings             Custom HTTP headers in 'Name: Value' format (use multiple times for multiple headers)
   -h, --help                       help for linktadoru
-      --ignore-robots              Ignore robots.txt rules
+      --ignore-robots-txt              Ignore robots.txt rules
       --include-patterns strings   Regex patterns for URLs to include
   -l, --limit int                  Stop after N pages (0=unlimited)
       --show-config                Display current configuration in YAML format and exit
@@ -45,7 +45,7 @@ concurrency: 2              # Number of concurrent workers (default: 2, was 10)
 request_delay: 0.1           # Delay between requests in seconds (default: 0.1, was 1.0)
 request_timeout: 30.0        # HTTP request timeout in seconds
 user_agent: "LinkTadoru/1.0" # User-Agent header
-ignore_robots: false        # Whether to ignore robots.txt rules
+ignore_robots_txt: false        # Whether to ignore robots.txt rules
 limit: 0                    # Stop after N pages (0 = unlimited)
 
 # Authentication configuration
@@ -90,7 +90,7 @@ export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.1
 export LT_REQUEST_TIMEOUT=30.0
 export LT_USER_AGENT="MyBot/1.0"
-export LT_IGNORE_ROBOTS=false
+export LT_IGNORE_ROBOTS_TXT=false
 export LT_DATABASE_PATH="./mysite.db"
 export LT_LIMIT=1000
 
@@ -134,8 +134,10 @@ export LT_HEADER_X_CUSTOM="MyCustomValue"
 | request_delay | `-r, --delay` | `LT_REQUEST_DELAY` | 0.1 | Delay between requests in seconds |
 | request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout |
 | user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
-| ignore_robots | `--ignore-robots` | `LT_IGNORE_ROBOTS` | false | Ignore robots.txt rules |
+| ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
+| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Allow crawling hosts other than the seed hosts |
 | limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
+| max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes |
 | database_path | `-d, --database` | `LT_DATABASE_PATH` | ./linktadoru.db | SQLite database file path |
 | **URL Filtering** |
 | include_patterns | `--include-patterns` | `LT_INCLUDE_PATTERNS` | [] | URL patterns to include (regex) |
@@ -314,6 +316,6 @@ request_delay: 200ms-500ms
 ```yaml
 concurrency: 2
 request_delay: 5s
-ignore_robots: false
+ignore_robots_txt: false
 user_agent: "PoliteBot/1.0 (https://httpbin.org/bot)"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ Create a `linktadoru.yml` file:
 # Basic crawling parameters (updated defaults)
 concurrency: 2              # Number of concurrent workers (default: 2, was 10)
 request_delay: 0.1           # Delay between requests in seconds (default: 0.1, was 1.0)
-request_timeout: 30.0        # HTTP request timeout in seconds
+request_timeout: "30s"       # HTTP request timeout (Go duration, e.g. "30s", "1m")
 user_agent: "LinkTadoru/1.0" # User-Agent header
 ignore_robots_txt: false        # Whether to ignore robots.txt rules
 limit: 0                    # Stop after N pages (0 = unlimited)
@@ -88,7 +88,7 @@ All configuration options can be set via environment variables with the `LT_` pr
 # Basic configuration
 export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.1
-export LT_REQUEST_TIMEOUT=30.0
+export LT_REQUEST_TIMEOUT=30s
 export LT_USER_AGENT="MyBot/1.0"
 export LT_IGNORE_ROBOTS_TXT=false
 export LT_DATABASE_PATH="./mysite.db"

--- a/docs/technical-specification.ja.md
+++ b/docs/technical-specification.ja.md
@@ -94,8 +94,9 @@ type CrawlConfig struct {
 pagesテーブルは二重の目的を果たします：
 
 **キュー管理:**
-- URLは`status='queued'`で開始
-- ワーカーがアトミックにアイテムを取得: `queued` → `processing`
+- クロール済みページから発見されたリンクは`status='discovered'`で記録される（グラフのノードであり、クロール対象ではない）
+- クロール対象に選ばれたURL（シード、またはinclude/excludeフィルタを通過した発見リンク）は`status='pending'`に昇格
+- ワーカーがアトミックにアイテムを取得: `pending` → `processing`
 - 完了時の更新: `processing` → `completed` または `error`
 
 **結果ストレージ:**
@@ -112,10 +113,10 @@ UPDATE pages
 SET status = 'processing', processing_started_at = ? 
 WHERE id = (
     SELECT id FROM pages 
-    WHERE status = 'queued' 
+    WHERE status = 'pending' 
     ORDER BY added_at ASC 
     LIMIT 1
-) AND status = 'queued'
+) AND status = 'pending'
 RETURNING id, url
 ```
 
@@ -124,7 +125,7 @@ RETURNING id, url
 - **競合状態の防止**: アトミック操作で排他アクセスを保証
 - **プロセス間安全性**: SQLiteトランザクションベースの自動ロック
 - **高性能**: 単一クエリでの取得と更新
-- **状態追跡**: 明確な遷移: `queued` → `processing` → `completed`/`error`
+- **状態追跡**: 明確な遷移: `discovered` → `pending` → `processing` → `completed`/`skipped`/`error`
 - **再開可能性**: 永続的な状態でプロセス中断を生き延びる
 
 ### 3. HTTPクライアント
@@ -173,7 +174,7 @@ SQLiteベースのストレージ：
 CREATE TABLE pages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     url TEXT UNIQUE NOT NULL,
-    status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'processing', 'completed', 'error')),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error', 'discovered')),
     
     -- キュー関連フィールド
     added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/docs/technical-specification.ja.md
+++ b/docs/technical-specification.ja.md
@@ -53,16 +53,22 @@ LinkTadoruは、SEO分析用に設計された高性能で並行処理可能なW
 
 ```go
 type CrawlConfig struct {
-    SeedURLs        []string      
-    Concurrency     int           
-    RequestDelay    time.Duration 
-    RequestTimeout  time.Duration 
-    UserAgent       string        
-    RespectRobots   bool          
-    IncludePatterns []string      
-    ExcludePatterns []string      
-    DatabasePath    string        
-    Limit           int
+    SeedURLs            []string
+    Concurrency         int
+    RequestDelay        float64       // 秒
+    RequestTimeout      time.Duration
+    UserAgent           string
+    IgnoreRobotsTxt     bool
+    FollowExternalHosts bool
+    Limit               int
+    MaxResponseSize     int64         // バイト
+    Auth                *Auth
+    IncludePatterns     []string
+    ExcludePatterns     []string
+    AllowedSchemes      []string
+    Headers             []string
+    DatabasePath        string
+    // ... ロギング設定 (LogLevel, LogFile, ...)
 }
 ```
 
@@ -97,7 +103,8 @@ pagesテーブルは二重の目的を果たします：
 - クロール済みページから発見されたリンクは`status='discovered'`で記録される（グラフのノードであり、クロール対象ではない）
 - クロール対象に選ばれたURL（シード、またはinclude/excludeフィルタを通過した発見リンク）は`status='pending'`に昇格
 - ワーカーがアトミックにアイテムを取得: `pending` → `processing`
-- 完了時の更新: `processing` → `completed` または `error`
+- 完了時の更新: `processing` → `completed`、`skipped`（robots.txt）、または `error`
+- 注: `completed` は「取得が完了した」ことを意味する。404などのHTTPエラーも`completed`となり、結果は`status_code`カラムに記録される
 
 **結果ストレージ:**
 - クロール結果フィールドは処理されるまで`NULL`

--- a/docs/technical-specification.md
+++ b/docs/technical-specification.md
@@ -94,9 +94,11 @@ The crawler implements a worker pool pattern with unified SQLite-based queue sys
 The pages table serves dual purposes:
 
 **Queue Management:**
-- URLs start with `status='queued'`
-- Workers atomically claim items: `queued` → `processing`
-- Completion updates: `processing` → `completed` or `error`
+- Link-graph nodes discovered on crawled pages start as `status='discovered'` (recorded, not crawled)
+- URLs selected for crawling (seeds, or discovered links passing the include/exclude filters) are promoted to `status='pending'`
+- Workers atomically claim items: `pending` → `processing`
+- Completion updates: `processing` → `completed`, `skipped` (robots.txt), or `error`
+- Note: `completed` means the fetch finished; HTTP errors such as 404 are still `completed` with the `status_code` column recording the result
 
 **Results Storage:**
 - Crawl result fields remain `NULL` until processed
@@ -112,10 +114,10 @@ UPDATE pages
 SET status = 'processing', processing_started_at = ? 
 WHERE id = (
     SELECT id FROM pages 
-    WHERE status = 'queued' 
+    WHERE status = 'pending' 
     ORDER BY added_at ASC 
     LIMIT 1
-) AND status = 'queued'
+) AND status = 'pending'
 RETURNING id, url
 ```
 
@@ -124,7 +126,7 @@ RETURNING id, url
 - **Race Condition Prevention**: Atomic operations ensure exclusive access
 - **Inter-process Safety**: SQLite transaction-based automatic locking
 - **High Performance**: Single query for acquire and update
-- **State Tracking**: Clear transitions: `queued` → `processing` → `completed`/`error`
+- **State Tracking**: Clear transitions: `discovered` → `pending` → `processing` → `completed`/`skipped`/`error`
 - **Resumability**: Persistent state survives process interruptions
 
 ### 3. HTTP Client
@@ -173,7 +175,7 @@ SQLite-based storage with:
 CREATE TABLE pages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     url TEXT UNIQUE NOT NULL,
-    status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'processing', 'completed', 'error')),
+    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error', 'discovered')),
     
     -- Queue-related fields
     added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/docs/technical-specification.md
+++ b/docs/technical-specification.md
@@ -53,16 +53,22 @@ The configuration system follows a hierarchical priority:
 
 ```go
 type CrawlConfig struct {
-    SeedURLs        []string      
-    Concurrency     int           
-    RequestDelay    time.Duration 
-    RequestTimeout  time.Duration 
-    UserAgent       string        
-    RespectRobots   bool          
-    IncludePatterns []string      
-    ExcludePatterns []string      
-    DatabasePath    string        
-    Limit           int
+    SeedURLs            []string
+    Concurrency         int
+    RequestDelay        float64       // seconds
+    RequestTimeout      time.Duration
+    UserAgent           string
+    IgnoreRobotsTxt     bool
+    FollowExternalHosts bool
+    Limit               int
+    MaxResponseSize     int64         // bytes
+    Auth                *Auth
+    IncludePatterns     []string
+    ExcludePatterns     []string
+    AllowedSchemes      []string
+    Headers             []string
+    DatabasePath        string
+    // ... logging options (LogLevel, LogFile, ...)
 }
 ```
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,6 +44,13 @@ func Execute() error {
 	return rootCmd.Execute()
 }
 
+// ExecuteContext is Execute with a caller-supplied context, so signal-driven
+// cancellation (SIGINT/SIGTERM in main) propagates to the crawler via
+// cmd.Context().
+func ExecuteContext(ctx context.Context) error {
+	return rootCmd.ExecuteContext(ctx)
+}
+
 // SetVersionInfo sets version information for the CLI
 func SetVersionInfo(v, bt string) {
 	version = v
@@ -67,6 +75,7 @@ func init() {
 	rootCmd.Flags().Bool("ignore-robots-txt", false, "Ignore robots.txt rules")
 	rootCmd.Flags().Bool("follow-external-hosts", false, "Allow crawling external hosts")
 	rootCmd.Flags().IntP("limit", "l", 0, "Stop after N pages (0=unlimited)")
+	rootCmd.Flags().Int64("max-response-size", 10*1024*1024, "Max response body size in bytes")
 
 	// Authentication type flag
 	rootCmd.Flags().String("auth-type", "", "Authentication type: 'basic', 'bearer', or 'api-key'")
@@ -104,6 +113,7 @@ func init() {
 		{"ignore_robots_txt", "ignore-robots-txt"},
 		{"follow_external_hosts", "follow-external-hosts"},
 		{"limit", "limit"},
+		{"max_response_size", "max-response-size"},
 		{"include_patterns", "include-patterns"},
 		{"exclude_patterns", "exclude-patterns"},
 		{"database_path", "database"},

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -304,24 +304,35 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	}
 
 	// Initialize and start the crawler
-	crawler, err := initializeCrawler(cfg)
+	crawler, store, err := initializeCrawler(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to initialize crawler: %w", err)
 	}
+	// Close in LIFO order: stop the crawler first, then close the database it
+	// writes to. Start only returns after its workers have finished, so no
+	// write can race the Close.
+	defer func() { _ = store.Close() }()
 	defer func() { _ = crawler.Stop() }()
 
 	// Start crawling
 	return crawler.Start(cmd.Context(), cfg.SeedURLs)
 }
 
-// initializeCrawler creates and configures a crawler instance
-func initializeCrawler(cfg *config.CrawlConfig) (crawler.Crawler, error) {
+// initializeCrawler creates and configures a crawler instance. The returned
+// storage is owned by the caller, which must Close it after stopping the
+// crawler.
+func initializeCrawler(cfg *config.CrawlConfig) (crawler.Crawler, *storage.SQLiteStorage, error) {
 	// Initialize storage
 	store, err := storage.NewSQLiteStorage(cfg.DatabasePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize storage: %w", err)
+		return nil, nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}
 
 	// Pass the complete config directly to the crawler
-	return crawler.NewCrawler(cfg, store)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		_ = store.Close()
+		return nil, nil, err
+	}
+	return c, store, nil
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -105,7 +105,7 @@ func TestInitializeCrawler(t *testing.T) {
 		Limit:           10,
 	}
 
-	crawler, err := initializeCrawler(cfg)
+	crawler, store, err := initializeCrawler(cfg)
 	if err != nil {
 		t.Fatalf("Failed to initialize crawler: %v", err)
 	}
@@ -113,10 +113,16 @@ func TestInitializeCrawler(t *testing.T) {
 	if crawler == nil {
 		t.Error("Crawler should not be nil")
 	}
+	if store == nil {
+		t.Error("Storage should not be nil")
+	}
 
 	// Clean up
 	if crawler != nil {
 		_ = crawler.Stop()
+	}
+	if store != nil {
+		_ = store.Close()
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,6 +60,7 @@ type CrawlConfig struct {
 	IgnoreRobotsTxt     bool          `mapstructure:"ignore_robots_txt" yaml:"ignore_robots_txt"`         // Whether to ignore robots.txt
 	FollowExternalHosts bool          `mapstructure:"follow_external_hosts" yaml:"follow_external_hosts"` // Whether to crawl external hosts
 	Limit               int           `mapstructure:"limit" yaml:"limit"`                                 // Stop after N pages
+	MaxResponseSize     int64         `mapstructure:"max_response_size" yaml:"max_response_size"`         // Max response body size in bytes (0 = default 10MiB)
 
 	// Authentication
 	Auth *Auth `mapstructure:"auth" yaml:"auth"` // Authentication configuration
@@ -91,8 +92,9 @@ func DefaultConfig() *CrawlConfig {
 		RequestTimeout:      30 * time.Second,
 		UserAgent:           "LinkTadoru/1.0",
 		IgnoreRobotsTxt:     false,
-		FollowExternalHosts: false, // Default to same-host only for safety
-		Limit:               0,     // unlimited
+		FollowExternalHosts: false,            // Default to same-host only for safety
+		Limit:               0,                // unlimited
+		MaxResponseSize:     10 * 1024 * 1024, // 10 MiB response body cap
 		DatabasePath:        "./linktadoru.db",
 		AllowedSchemes:      []string{"https://", "http://"}, // Default allowed URL schemes
 		// Logging defaults

--- a/internal/crawler/audit_fixes_test.go
+++ b/internal/crawler/audit_fixes_test.go
@@ -1,0 +1,155 @@
+package crawler
+
+// Regression tests for the project-audit fixes: response body size limit,
+// startup validation of URL filter patterns, rate-limiter idempotence, and
+// robots.txt crawl-delay wiring.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/masahif/linktadoru/internal/config"
+)
+
+func TestHTTPClientEnforcesResponseSizeLimit(t *testing.T) {
+	big := strings.Repeat("x", 64*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(big))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient("LinkTadoru-Test/1.0", 5*time.Second)
+	client.SetMaxResponseSize(1024)
+
+	_, err := client.Get(context.Background(), server.URL)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("Get on oversized body: err = %v, want ErrResponseTooLarge", err)
+	}
+
+	// A body exactly at the limit must succeed.
+	client.SetMaxResponseSize(int64(len(big)))
+	resp, err := client.Get(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Get at exactly the limit failed: %v", err)
+	}
+	if len(resp.Body) != len(big) {
+		t.Errorf("body truncated: got %d bytes, want %d", len(resp.Body), len(big))
+	}
+}
+
+// An oversized page must be classified as the deterministic
+// 'response_too_large' (excluded from retry), not the transient
+// 'network_error' (retried).
+func TestPageProcessorClassifiesOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(strings.Repeat("x", 8192)))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClient("LinkTadoru-Test/1.0", 5*time.Second)
+	client.SetMaxResponseSize(1024)
+	processor := NewPageProcessor(client)
+
+	result, err := processor.Process(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+	if result.Error == nil {
+		t.Fatal("expected a CrawlError for the oversized response")
+	}
+	if result.Error.ErrorType != "response_too_large" {
+		t.Errorf("ErrorType = %q, want response_too_large", result.Error.ErrorType)
+	}
+}
+
+// An invalid pattern must fail crawler construction loudly. Before this fix
+// regexp.MatchString errors were discarded, so a bad pattern silently never
+// matched — the same "configured but ineffective" failure mode as issue #46.
+func TestNewCrawlerRejectsInvalidPatterns(t *testing.T) {
+	base := func() *config.CrawlConfig {
+		return &config.CrawlConfig{
+			Concurrency:    1,
+			RequestDelay:   0.1,
+			RequestTimeout: time.Second,
+			UserAgent:      "LinkTadoru-Test/1.0",
+		}
+	}
+
+	cfg := base()
+	cfg.IncludePatterns = []string{"["}
+	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "include_patterns") {
+		t.Errorf("invalid include pattern: err = %v, want include_patterns compile error", err)
+	}
+
+	cfg = base()
+	cfg.ExcludePatterns = []string{"(unclosed"}
+	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "exclude_patterns") {
+		t.Errorf("invalid exclude pattern: err = %v, want exclude_patterns compile error", err)
+	}
+}
+
+// Re-applying the same delay must not replace the limiter: a fresh limiter has
+// a full token bucket, so replacing it on every request would effectively
+// disable rate limiting.
+func TestSetDomainDelayIdempotent(t *testing.T) {
+	rl := NewRateLimiter(10 * time.Millisecond)
+
+	rl.SetDomainDelay("example.com", 50*time.Millisecond)
+	first := rl.getLimiter("example.com")
+
+	rl.SetDomainDelay("example.com", 50*time.Millisecond)
+	if rl.getLimiter("example.com") != first {
+		t.Error("same delay replaced the limiter (token bucket reset)")
+	}
+
+	rl.SetDomainDelay("example.com", 100*time.Millisecond)
+	if rl.getLimiter("example.com") == first {
+		t.Error("changed delay did not replace the limiter")
+	}
+}
+
+// The robots.txt Crawl-delay directive must reach the rate limiter when it is
+// slower than the configured default.
+func TestCrawlDelayFromRobotsIsApplied(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/robots.txt" {
+			_, _ = w.Write([]byte("User-agent: *\nCrawl-delay: 2\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
+	}))
+	defer server.Close()
+
+	cfg := &config.CrawlConfig{
+		SeedURLs:       []string{server.URL},
+		Concurrency:    1,
+		RequestDelay:   0.1,
+		RequestTimeout: 5 * time.Second,
+		UserAgent:      "LinkTadoru-Test/1.0",
+	}
+	c, err := NewCrawler(cfg, &MockStorage{})
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	c.ctx = context.Background() // normally set by Start
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	if !c.shouldProcessURL(0, &URLItem{ID: 1, URL: server.URL + "/page"}) {
+		t.Fatal("URL unexpectedly disallowed")
+	}
+
+	c.rateLimiter.mu.RLock()
+	applied := c.rateLimiter.delays[host]
+	c.rateLimiter.mu.RUnlock()
+	if applied != 2*time.Second {
+		t.Errorf("crawl-delay applied to rate limiter = %v, want 2s", applied)
+	}
+}

--- a/internal/crawler/audit_integration_test.go
+++ b/internal/crawler/audit_integration_test.go
@@ -1,0 +1,115 @@
+package crawler_test
+
+// Integration regressions for the audit-fix review findings: the retry phase
+// must actually run after a completed crawl, and cancellation must make Start
+// return promptly after its workers wind down.
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/masahif/linktadoru/internal/crawler"
+	"github.com/masahif/linktadoru/internal/storage"
+
+	_ "modernc.org/sqlite"
+)
+
+// The retry phase was unreachable for the project's entire history: the last
+// exiting worker cancelled the crawl context (to stop the stats reporter),
+// which made Start take its "cancelled" branch instead of calling
+// performRetries. A retry_count of 2 — initial attempt plus exactly one retry
+// pass — proves the phase now runs.
+func TestRetryPhaseRunsAfterCrawlCompletes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := server.URL
+	server.Close() // connection refused from here on
+
+	dbPath := filepath.Join(t.TempDir(), "retry.db")
+	store, err := storage.NewSQLiteStorage(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStorage: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{deadURL}
+	cfg.RequestTimeout = 2 * time.Second
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	done := make(chan error, 1)
+	go func() { done <- c.Start(context.Background(), cfg.SeedURLs) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("crawler did not terminate")
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open assertion connection: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var status string
+	var retryCount int
+	if err := db.QueryRow(
+		"SELECT status, retry_count FROM pages WHERE url = ?", deadURL,
+	).Scan(&status, &retryCount); err != nil {
+		t.Fatalf("select seed row: %v", err)
+	}
+	if status != "error" {
+		t.Errorf("status = %q, want error", status)
+	}
+	if retryCount != 2 {
+		t.Errorf("retry_count = %d, want 2 (initial attempt + one retry pass)", retryCount)
+	}
+}
+
+// On cancellation Start must wait for its workers (graceful shutdown) but then
+// return promptly — the in-flight HTTP request carries the crawl context, so a
+// worker stuck on a slow server unblocks as soon as the context is cancelled.
+func TestStartReturnsPromptlyOnCancel(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hold every request until the test ends
+	}))
+	defer server.Close()
+	defer close(release)
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{server.URL}
+	cfg.RequestTimeout = 60 * time.Second // only cancellation can unblock
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatalf("NewCrawler: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Stop() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.Start(ctx, cfg.SeedURLs) }()
+
+	time.AfterFunc(200*time.Millisecond, cancel)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -487,17 +487,25 @@ func (c *DefaultCrawler) shouldProcessURL(id int, item *URLItem) bool {
 	// Honor the robots.txt Crawl-delay directive when it asks for a slower
 	// pace than our configured default, capped so a hostile or mistyped value
 	// (e.g. Crawl-delay: 86400) cannot park the crawl for hours per request.
-	// SetDomainDelay is a no-op when the delay is unchanged, so calling it per
-	// URL does not reset the limiter.
+	// The cap never goes below the user's configured delay — robots.txt may
+	// only slow us down, never speed us up. SetDomainDelay reports whether it
+	// actually changed anything, so the warning fires once per domain rather
+	// than on every URL.
 	const maxCrawlDelay = 60 * time.Second
 	if u, err := url.Parse(item.URL); err == nil {
 		defaultDelay := time.Duration(c.config.RequestDelay * float64(time.Second))
 		if d := c.robotsParser.GetCrawlDelay(u.Host); d > defaultDelay {
-			if d > maxCrawlDelay {
-				slog.Warn("Capping excessive robots.txt crawl-delay", "domain", u.Host, "requested", d, "capped_to", maxCrawlDelay)
-				d = maxCrawlDelay
+			limit := time.Duration(maxCrawlDelay)
+			if defaultDelay > limit {
+				limit = defaultDelay
 			}
-			c.rateLimiter.SetDomainDelay(u.Host, d)
+			capped := d > limit
+			if capped {
+				d = limit
+			}
+			if c.rateLimiter.SetDomainDelay(u.Host, d) && capped {
+				slog.Warn("Capped excessive robots.txt crawl-delay", "domain", u.Host, "applied", d)
+			}
 		}
 	}
 
@@ -516,6 +524,14 @@ func (c *DefaultCrawler) handleProcessingError(id int, item *URLItem, err error)
 
 // handleProcessingResult handles successful page processing results
 func (c *DefaultCrawler) handleProcessingResult(id int, item *URLItem, result *PageResult) {
+	// A fetch aborted by run cancellation is not a page failure: leave the row
+	// 'processing' (the next run's CleanupStaleProcessing requeues it) instead
+	// of burning a retry credit and recording a phantom "context canceled"
+	// page error. Page == nil implies there are no links to save either.
+	if result.Page == nil && c.ctx.Err() != nil {
+		return
+	}
+
 	// Save links and queue newly discovered URLs BEFORE marking this page
 	// completed. While this runs, item.ID is still 'processing', so
 	// HasQueuedItems() stays true across the whole window — an idle sibling

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -33,13 +33,11 @@ type DefaultCrawler struct {
 	excludePatterns []*regexp.Regexp
 
 	// State
-	stats         CrawlStats
-	statsMutex    sync.RWMutex
-	ctx           context.Context
-	cancel        context.CancelFunc
-	wg            sync.WaitGroup
-	activeWorkers int
-	workersMutex  sync.Mutex
+	stats      CrawlStats
+	statsMutex sync.RWMutex
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup // tracks workers only (not the stats reporter)
 }
 
 // NewCrawler creates a new crawler instance with the provided configuration and storage.
@@ -249,33 +247,41 @@ func (c *DefaultCrawler) Start(ctx context.Context, seedURLs []string) error {
 	}
 
 	// Step 2: Start workers after queue is populated
-	c.activeWorkers = c.config.Concurrency
 	for i := 0; i < c.config.Concurrency; i++ {
 		c.wg.Add(1)
 		go c.worker(i)
 	}
 
-	// Start stats reporter
-	c.wg.Add(1)
-	go c.statsReporter()
-
-	// Wait for completion or context cancellation
-	done := make(chan struct{})
+	// The stats reporter lives outside the worker WaitGroup: it only exits on
+	// context cancellation, so tracking it in c.wg would keep wg.Wait from
+	// ever returning on natural completion. (An earlier design had the last
+	// exiting worker cancel the context to stop the reporter — but that made
+	// Start unable to tell natural completion from cancellation, so the retry
+	// phase below was unreachable and retries never ran.)
+	statsDone := make(chan struct{})
 	go func() {
-		c.wg.Wait()
-		close(done)
+		defer close(statsDone)
+		c.statsReporter()
 	}()
 
-	select {
-	case <-done:
+	// Always wait for the workers themselves. On external cancellation they
+	// exit promptly (in-flight requests carry c.ctx), and waiting here is what
+	// makes shutdown graceful: Start does not return while a worker may still
+	// be writing to the database.
+	c.wg.Wait()
+
+	if c.ctx.Err() != nil {
+		slog.Info("Crawling cancelled")
+	} else {
 		slog.Info("Crawling completed - checking for retries")
-		// After normal crawling completes, attempt retries
 		if err := c.performRetries(); err != nil {
 			slog.Error("Error during retry processing", "error", err)
 		}
-	case <-c.ctx.Done():
-		slog.Info("Crawling cancelled")
 	}
+
+	// Stop the stats reporter and wait for it before returning.
+	c.cancel()
+	<-statsDone
 
 	return nil
 }
@@ -313,9 +319,9 @@ func (c *DefaultCrawler) performRetries() error {
 
 		if hasItems {
 			slog.Info("Starting retry processing")
-			// Start workers again for retry processing
-			c.wg = sync.WaitGroup{} // Reset wait group
-			c.activeWorkers = c.config.Concurrency
+			// Start workers again for retry processing. c.wg is empty here
+			// (Start waited for all workers before calling us) and c.ctx is
+			// still live, so the retry workers actually run.
 			for i := 0; i < c.config.Concurrency; i++ {
 				c.wg.Add(1)
 				go c.worker(i)
@@ -356,7 +362,7 @@ func (c *DefaultCrawler) GetStats() CrawlStats {
 // 3. No queued items available (SELECT returns empty result)
 func (c *DefaultCrawler) worker(id int) {
 	defer c.wg.Done()
-	defer c.handleWorkerShutdown(id)
+	defer slog.Debug("Worker stopped", "worker_id", id)
 
 	slog.Debug("Worker started", "worker_id", id)
 
@@ -388,18 +394,6 @@ func (c *DefaultCrawler) worker(id int) {
 			c.processURLItem(id, item)
 		}
 	}
-}
-
-// handleWorkerShutdown handles worker cleanup when shutting down
-func (c *DefaultCrawler) handleWorkerShutdown(id int) {
-	c.workersMutex.Lock()
-	c.activeWorkers--
-	if c.activeWorkers == 0 {
-		// All workers are done, cancel context to stop stats reporter
-		c.cancel()
-	}
-	c.workersMutex.Unlock()
-	slog.Debug("Worker stopped", "worker_id", id)
 }
 
 // shouldStopWorker checks if worker should stop due to limit reached
@@ -491,11 +485,18 @@ func (c *DefaultCrawler) shouldProcessURL(id int, item *URLItem) bool {
 	}
 
 	// Honor the robots.txt Crawl-delay directive when it asks for a slower
-	// pace than our configured default. SetDomainDelay is a no-op when the
-	// delay is unchanged, so calling it per URL does not reset the limiter.
+	// pace than our configured default, capped so a hostile or mistyped value
+	// (e.g. Crawl-delay: 86400) cannot park the crawl for hours per request.
+	// SetDomainDelay is a no-op when the delay is unchanged, so calling it per
+	// URL does not reset the limiter.
+	const maxCrawlDelay = 60 * time.Second
 	if u, err := url.Parse(item.URL); err == nil {
 		defaultDelay := time.Duration(c.config.RequestDelay * float64(time.Second))
 		if d := c.robotsParser.GetCrawlDelay(u.Host); d > defaultDelay {
+			if d > maxCrawlDelay {
+				slog.Warn("Capping excessive robots.txt crawl-delay", "domain", u.Host, "requested", d, "capped_to", maxCrawlDelay)
+				d = maxCrawlDelay
+			}
 			c.rateLimiter.SetDomainDelay(u.Host, d)
 		}
 	}
@@ -599,8 +600,6 @@ func (c *DefaultCrawler) logProcessingResult(id int, url string, result *PageRes
 
 // statsReporter periodically reports crawling statistics
 func (c *DefaultCrawler) statsReporter() {
-	defer c.wg.Done()
-
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -26,6 +26,12 @@ type DefaultCrawler struct {
 	robotsParser *RobotsParser
 	allowedHosts []string // Hosts allowed for crawling (from seed URLs)
 
+	// Include/exclude patterns compiled once at construction. Compiling here
+	// (a) rejects an invalid pattern at startup instead of silently never
+	// matching it, and (b) avoids recompiling every pattern for every URL.
+	includePatterns []*regexp.Regexp
+	excludePatterns []*regexp.Regexp
+
 	// State
 	stats         CrawlStats
 	statsMutex    sync.RWMutex
@@ -44,6 +50,7 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 
 	// Initialize HTTP client
 	httpClient := NewHTTPClient(config.UserAgent, config.RequestTimeout)
+	httpClient.SetMaxResponseSize(config.MaxResponseSize)
 
 	// Configure basic authentication if provided
 	if config.Auth != nil {
@@ -117,20 +124,47 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 		}
 	}
 
+	// Compile URL filter patterns up front so an invalid regex fails the run
+	// loudly instead of being silently ignored on every URL.
+	includePatterns, err := compilePatterns(config.IncludePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("invalid include_patterns: %w", err)
+	}
+	excludePatterns, err := compilePatterns(config.ExcludePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("invalid exclude_patterns: %w", err)
+	}
+
 	crawler := &DefaultCrawler{
-		config:       config,
-		storage:      storage,
-		httpClient:   httpClient,
-		processor:    processor,
-		rateLimiter:  rateLimiter,
-		robotsParser: robotsParser,
-		allowedHosts: allowedHosts,
+		config:          config,
+		storage:         storage,
+		httpClient:      httpClient,
+		processor:       processor,
+		rateLimiter:     rateLimiter,
+		robotsParser:    robotsParser,
+		allowedHosts:    allowedHosts,
+		includePatterns: includePatterns,
+		excludePatterns: excludePatterns,
 		stats: CrawlStats{
 			StartTime: time.Now(),
 		},
 	}
 
 	return crawler, nil
+}
+
+// compilePatterns compiles a list of regex patterns, reporting the offending
+// pattern on failure.
+func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("pattern %q: %w", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled, nil
 }
 
 // isAllowedHost checks if the given URL's host is allowed for crawling
@@ -455,6 +489,17 @@ func (c *DefaultCrawler) shouldProcessURL(id int, item *URLItem) bool {
 		c.workerSleep()
 		return false
 	}
+
+	// Honor the robots.txt Crawl-delay directive when it asks for a slower
+	// pace than our configured default. SetDomainDelay is a no-op when the
+	// delay is unchanged, so calling it per URL does not reset the limiter.
+	if u, err := url.Parse(item.URL); err == nil {
+		defaultDelay := time.Duration(c.config.RequestDelay * float64(time.Second))
+		if d := c.robotsParser.GetCrawlDelay(u.Host); d > defaultDelay {
+			c.rateLimiter.SetDomainDelay(u.Host, d)
+		}
+	}
+
 	return true
 }
 
@@ -587,10 +632,10 @@ func (c *DefaultCrawler) shouldCrawlURL(urlStr string) bool {
 	}
 
 	// If include patterns are specified, URL must match at least one
-	if len(c.config.IncludePatterns) > 0 {
+	if len(c.includePatterns) > 0 {
 		matched := false
-		for _, pattern := range c.config.IncludePatterns {
-			if m, _ := regexp.MatchString(pattern, urlStr); m {
+		for _, re := range c.includePatterns {
+			if re.MatchString(urlStr) {
 				matched = true
 				break
 			}
@@ -601,8 +646,8 @@ func (c *DefaultCrawler) shouldCrawlURL(urlStr string) bool {
 	}
 
 	// Check exclude patterns - URL must not match any
-	for _, pattern := range c.config.ExcludePatterns {
-		if matched, _ := regexp.MatchString(pattern, urlStr); matched {
+	for _, re := range c.excludePatterns {
+		if re.MatchString(urlStr) {
 			return false
 		}
 	}

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -207,10 +207,11 @@ func (c *DefaultCrawler) isAllowedScheme(targetURL string) bool {
 
 // Start starts the crawling process
 // Startup process:
-// 1. Add seed URLs to queue with 'queued' status
-// 2. Start configured number of workers
-// 3. Workers compete for 'queued' items using atomic status updates
-// 4. Continue until queue is empty or limits reached
+//  1. Add seed URLs to queue with 'pending' status
+//  2. Start configured number of workers
+//  3. Workers compete for 'pending' items using atomic status updates
+//  4. Continue until queue is empty or limits reached, then retry
+//     transient failures once before returning
 func (c *DefaultCrawler) Start(ctx context.Context, seedURLs []string) error {
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	defer c.cancel()

--- a/internal/crawler/http_client.go
+++ b/internal/crawler/http_client.go
@@ -3,6 +3,7 @@ package crawler
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,17 +11,28 @@ import (
 	"time"
 )
 
+// DefaultMaxResponseSize bounds how many bytes of a response body are read
+// when no explicit limit is configured. Without a bound, a single huge (or
+// malicious) response would be read entirely into memory.
+const DefaultMaxResponseSize = 10 * 1024 * 1024 // 10 MiB
+
+// ErrResponseTooLarge is returned when a response body exceeds the configured
+// size limit. Callers can detect it with errors.Is to classify the failure as
+// deterministic (not worth retrying).
+var ErrResponseTooLarge = errors.New("response body exceeds size limit")
+
 // HTTPClient handles HTTP requests with performance metrics
 type HTTPClient struct {
-	client        *http.Client
-	userAgent     string
-	authType      string
-	username      string            // Basic auth username
-	password      string            // Basic auth password
-	bearerToken   string            // Bearer token
-	apiKeyHeader  string            // API key header name
-	apiKeyValue   string            // API key header value
-	customHeaders map[string]string // Custom headers
+	client          *http.Client
+	userAgent       string
+	maxResponseSize int64 // Max bytes to read from a response body
+	authType        string
+	username        string            // Basic auth username
+	password        string            // Basic auth password
+	bearerToken     string            // Bearer token
+	apiKeyHeader    string            // API key header name
+	apiKeyValue     string            // API key header value
+	customHeaders   map[string]string // Custom headers
 }
 
 // HTTPMetrics contains performance metrics for an HTTP request
@@ -67,9 +79,18 @@ func NewHTTPClient(userAgent string, timeout time.Duration) *HTTPClient {
 	}
 
 	return &HTTPClient{
-		client:        client,
-		userAgent:     userAgent,
-		customHeaders: make(map[string]string),
+		client:          client,
+		userAgent:       userAgent,
+		maxResponseSize: DefaultMaxResponseSize,
+		customHeaders:   make(map[string]string),
+	}
+}
+
+// SetMaxResponseSize overrides the response body size limit (bytes).
+// Values <= 0 keep the current limit.
+func (h *HTTPClient) SetMaxResponseSize(n int64) {
+	if n > 0 {
+		h.maxResponseSize = n
 	}
 }
 
@@ -200,10 +221,14 @@ func (h *HTTPClient) Get(ctx context.Context, url string) (*HTTPResponse, error)
 		metrics.TTFB = firstByteTime.Sub(startTime)
 	}
 
-	// Read response body
-	body, err := io.ReadAll(resp.Body)
+	// Read response body, bounded so a huge response cannot exhaust memory.
+	// Read one extra byte to distinguish "exactly at the limit" from "over it".
+	body, err := io.ReadAll(io.LimitReader(resp.Body, h.maxResponseSize+1))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if int64(len(body)) > h.maxResponseSize {
+		return nil, fmt.Errorf("%w (%d bytes limit): %s", ErrResponseTooLarge, h.maxResponseSize, url)
 	}
 
 	// Calculate total download time

--- a/internal/crawler/interfaces.go
+++ b/internal/crawler/interfaces.go
@@ -36,7 +36,6 @@ type Storage interface {
 
 	// Queue status
 	GetQueueStatus() (pending int, processing int, completed int, errors int, err error)
-	GetProcessingItems() ([]URLItem, error)
 	CleanupStaleProcessing(timeout time.Duration) error
 	HasQueuedItems() (bool, error) // Check if queue has any work items (pending or processing)
 

--- a/internal/crawler/limit_test.go
+++ b/internal/crawler/limit_test.go
@@ -50,10 +50,6 @@ func (m *MockStorage) GetQueueStatus() (pending int, processing int, completed i
 	return 0, 0, 0, 0, nil
 }
 
-func (m *MockStorage) GetProcessingItems() ([]URLItem, error) {
-	return nil, nil
-}
-
 func (m *MockStorage) CleanupStaleProcessing(timeout time.Duration) error {
 	return nil
 }

--- a/internal/crawler/page_processor.go
+++ b/internal/crawler/page_processor.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"time"
@@ -40,10 +41,17 @@ func (p *DefaultPageProcessor) Process(ctx context.Context, url string) (*PageRe
 	// Fetch the page
 	resp, err := p.httpClient.Get(ctx, url)
 	if err != nil {
+		// Distinguish the deterministic over-size case from transient network
+		// failures: 'network_error' is retried, 'response_too_large' is not
+		// (see storage.retryableErrorTypes).
+		errorType := "network_error"
+		if errors.Is(err, ErrResponseTooLarge) {
+			errorType = "response_too_large"
+		}
 		return &PageResult{
 			Error: &CrawlError{
 				URL:          url,
-				ErrorType:    "network_error",
+				ErrorType:    errorType,
 				ErrorMessage: err.Error(),
 				OccurredAt:   time.Now().UTC(),
 			},

--- a/internal/crawler/rate_limiter.go
+++ b/internal/crawler/rate_limiter.go
@@ -39,10 +39,11 @@ func (r *RateLimiter) Wait(ctx context.Context, urlStr string) error {
 	return limiter.Wait(ctx)
 }
 
-// SetDomainDelay sets a custom delay for a specific domain. Calling it again
-// with the same delay is a no-op — replacing the limiter would reset its token
-// bucket and effectively disable rate limiting when called on every request.
-func (r *RateLimiter) SetDomainDelay(domain string, delay time.Duration) {
+// SetDomainDelay sets a custom delay for a specific domain and reports whether
+// the delay changed. Calling it again with the same delay is a no-op —
+// replacing the limiter would reset its token bucket and effectively disable
+// rate limiting when called on every request.
+func (r *RateLimiter) SetDomainDelay(domain string, delay time.Duration) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -51,11 +52,12 @@ func (r *RateLimiter) SetDomainDelay(domain string, delay time.Duration) {
 	}
 
 	if current, ok := r.delays[domain]; ok && current == delay {
-		return
+		return false
 	}
 
 	r.delays[domain] = delay
 	r.limiters[domain] = rate.NewLimiter(rate.Every(delay), 1)
+	return true
 }
 
 // getLimiter gets or creates a rate limiter for a domain

--- a/internal/crawler/rate_limiter.go
+++ b/internal/crawler/rate_limiter.go
@@ -12,6 +12,7 @@ import (
 // RateLimiter manages rate limiting per domain
 type RateLimiter struct {
 	limiters map[string]*rate.Limiter
+	delays   map[string]time.Duration // effective delay per domain, to make SetDomainDelay idempotent
 	mu       sync.RWMutex
 	delay    time.Duration
 }
@@ -20,6 +21,7 @@ type RateLimiter struct {
 func NewRateLimiter(defaultDelay time.Duration) *RateLimiter {
 	return &RateLimiter{
 		limiters: make(map[string]*rate.Limiter),
+		delays:   make(map[string]time.Duration),
 		delay:    defaultDelay,
 	}
 }
@@ -37,7 +39,9 @@ func (r *RateLimiter) Wait(ctx context.Context, urlStr string) error {
 	return limiter.Wait(ctx)
 }
 
-// SetDomainDelay sets a custom delay for a specific domain
+// SetDomainDelay sets a custom delay for a specific domain. Calling it again
+// with the same delay is a no-op — replacing the limiter would reset its token
+// bucket and effectively disable rate limiting when called on every request.
 func (r *RateLimiter) SetDomainDelay(domain string, delay time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -46,8 +50,12 @@ func (r *RateLimiter) SetDomainDelay(domain string, delay time.Duration) {
 		delay = r.delay
 	}
 
-	limit := rate.Every(delay)
-	r.limiters[domain] = rate.NewLimiter(limit, 1)
+	if current, ok := r.delays[domain]; ok && current == delay {
+		return
+	}
+
+	r.delays[domain] = delay
+	r.limiters[domain] = rate.NewLimiter(rate.Every(delay), 1)
 }
 
 // getLimiter gets or creates a rate limiter for a domain
@@ -72,6 +80,7 @@ func (r *RateLimiter) getLimiter(domain string) *rate.Limiter {
 	limit := rate.Every(r.delay)
 	limiter = rate.NewLimiter(limit, 1)
 	r.limiters[domain] = limiter
+	r.delays[domain] = r.delay
 
 	return limiter
 }

--- a/internal/crawler/robots.go
+++ b/internal/crawler/robots.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
 	"sync"
@@ -49,7 +50,9 @@ func (r *RobotsParser) IsAllowed(ctx context.Context, urlStr string, userAgent s
 	domain := parsedURL.Host
 	rules, err := r.getRules(ctx, domain, parsedURL.Scheme)
 	if err != nil {
-		// If we can't fetch robots.txt, assume allowed
+		// Fail open: if robots.txt cannot be fetched, assume allowed — but say
+		// so, since this silently bypasses the site's crawling policy.
+		slog.Warn("Failed to fetch robots.txt, assuming allowed", "domain", domain, "error", err)
 		return true, nil
 	}
 
@@ -172,6 +175,8 @@ func (r *RobotsParser) parseRobotsTxt(content string) *RobotRules {
 			if inUserAgent {
 				if delay, err := time.ParseDuration(value + "s"); err == nil {
 					rules.CrawlDelay = delay
+				} else {
+					slog.Warn("Ignoring malformed robots.txt crawl-delay", "value", value)
 				}
 			}
 

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -2,10 +2,22 @@ package crawler
 
 import (
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/masahif/linktadoru/internal/config"
 )
+
+// mustCompilePatterns compiles URL filter patterns for tests that construct
+// DefaultCrawler directly instead of going through NewCrawler.
+func mustCompilePatterns(t *testing.T, patterns []string) []*regexp.Regexp {
+	t.Helper()
+	compiled, err := compilePatterns(patterns)
+	if err != nil {
+		t.Fatalf("failed to compile patterns %v: %v", patterns, err)
+	}
+	return compiled
+}
 
 func TestShouldCrawlURL(t *testing.T) {
 	tests := []struct {
@@ -130,7 +142,9 @@ func TestShouldCrawlURL(t *testing.T) {
 					ExcludePatterns:     tt.excludePatterns,
 					FollowExternalHosts: true, // Allow all hosts for legacy tests
 				},
-				allowedHosts: []string{}, // Empty list but external hosts allowed
+				allowedHosts:    []string{}, // Empty list but external hosts allowed
+				includePatterns: mustCompilePatterns(t, tt.includePatterns),
+				excludePatterns: mustCompilePatterns(t, tt.excludePatterns),
 			}
 
 			result := crawler.shouldCrawlURL(tt.url)
@@ -378,8 +392,10 @@ func TestShouldCrawlURLWithHostFiltering(t *testing.T) {
 			}
 
 			crawler := &DefaultCrawler{
-				config:       config,
-				allowedHosts: allowedHosts,
+				config:          config,
+				allowedHosts:    allowedHosts,
+				includePatterns: mustCompilePatterns(t, config.IncludePatterns),
+				excludePatterns: mustCompilePatterns(t, config.ExcludePatterns),
 			}
 
 			result := crawler.shouldCrawlURL(tt.targetURL)

--- a/internal/parser/fragment_test.go
+++ b/internal/parser/fragment_test.go
@@ -1,0 +1,41 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fragments identify positions within one page, not distinct resources.
+// resolveURL must strip them so "…/page#a" and "…/page#b" dedupe to the same
+// pages row instead of being crawled twice.
+func TestParseStripsURLFragments(t *testing.T) {
+	p, err := NewHTMLParser("https://example.com/base")
+	if err != nil {
+		t.Fatalf("NewHTMLParser: %v", err)
+	}
+
+	html := `<html><body>
+		<a href="/page#section-a">a</a>
+		<a href="/page#section-b">b</a>
+		<a href="https://example.com/other#top">c</a>
+	</body></html>`
+
+	result, err := p.Parse([]byte(html))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	seen := map[string]int{}
+	for _, link := range result.Links {
+		if strings.Contains(link.URL, "#") {
+			t.Errorf("fragment not stripped: %s", link.URL)
+		}
+		seen[link.URL]++
+	}
+	if seen["https://example.com/page"] != 2 {
+		t.Errorf("expected both fragment variants to resolve to the same URL, got %v", seen)
+	}
+	if seen["https://example.com/other"] != 1 {
+		t.Errorf("expected absolute link without fragment, got %v", seen)
+	}
+}

--- a/internal/parser/html_parser.go
+++ b/internal/parser/html_parser.go
@@ -212,6 +212,12 @@ func (p *HTMLParser) resolveURL(href string) (string, error) {
 
 	// Resolve relative to base URL
 	resolved := p.baseURL.ResolveReference(u)
+
+	// Drop the fragment: "…/page#a" and "…/page#b" are the same resource, and
+	// keeping fragments would create duplicate rows (pages.url is UNIQUE) and
+	// duplicate crawls of the same page.
+	resolved.Fragment = ""
+
 	return resolved.String(), nil
 }
 

--- a/internal/storage/issue46_test.go
+++ b/internal/storage/issue46_test.go
@@ -151,7 +151,7 @@ func TestAddToQueuePromotesOnlyDiscovered(t *testing.T) {
 		{
 			name: "error",
 			setup: func(t *testing.T, s *SQLiteStorage, id int) {
-				if err := s.SavePageError(id, "network_timeout", "boom"); err != nil {
+				if err := s.SavePageError(id, "processing_error", "boom"); err != nil {
 					t.Fatalf("SavePageError: %v", err)
 				}
 			},

--- a/internal/storage/retry_test.go
+++ b/internal/storage/retry_test.go
@@ -58,6 +58,31 @@ func TestRetryEligibilityMatchesWrittenErrorTypes(t *testing.T) {
 	}
 }
 
+// Rows written by older releases carry Go's local-timezone time.String() form.
+// A local date can be AHEAD of the current UTC date (e.g. JST just after local
+// midnight), making the legacy string compare greater than a UTC cutoff — so a
+// plain `< cutoff` would skip it and the resume would hang on the stuck
+// 'processing' row. Any non-current-format timestamp must be treated as stale.
+func TestCleanupStaleProcessingResetsLegacyFormatRows(t *testing.T) {
+	store := newTempStorage(t)
+
+	// Far-future local-format value: maximally adversarial for `< cutoff`.
+	legacy := "2030-01-01 09:00:00.5 +0900 JST"
+	if _, err := store.db.Exec(
+		"INSERT INTO pages (url, status, processing_started_at) VALUES ('https://example.com/legacy-ts', 'processing', ?)",
+		legacy,
+	); err != nil {
+		t.Fatalf("seed legacy row: %v", err)
+	}
+
+	if err := store.CleanupStaleProcessing(0); err != nil {
+		t.Fatalf("CleanupStaleProcessing: %v", err)
+	}
+	if got := mustStatus(t, store, "https://example.com/legacy-ts"); got != "pending" {
+		t.Errorf("legacy-format processing row status = %q, want pending (reset)", got)
+	}
+}
+
 // Timestamps must be stored in the fixed-width UTC layout so string comparison
 // in SQL matches chronological order regardless of local timezone/DST.
 func TestTimestampsStoredInFixedWidthUTC(t *testing.T) {

--- a/internal/storage/retry_test.go
+++ b/internal/storage/retry_test.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"testing"
+	"time"
+)
+
+// The retryable set must match the error types the crawler actually writes.
+// Before this test existed, the SQL filtered on types nothing ever wrote
+// ('network_timeout', ...), so the retry mechanism silently never fired.
+func TestRetryEligibilityMatchesWrittenErrorTypes(t *testing.T) {
+	store := newTempStorage(t)
+
+	// One errored page per error type the crawler can write (see
+	// page_processor.go and crawler.go SavePageError call sites).
+	errorTypes := map[string]string{
+		"https://example.com/net":  "network_error",
+		"https://example.com/proc": "processing_error",
+		"https://example.com/rate": "rate_limit_error",
+		"https://example.com/big":  "response_too_large",
+	}
+	for u, et := range errorTypes {
+		if err := store.AddToQueue([]string{u}); err != nil {
+			t.Fatalf("AddToQueue(%s): %v", u, err)
+		}
+		item, err := store.GetNextFromQueue()
+		if err != nil || item == nil {
+			t.Fatalf("GetNextFromQueue(%s): item=%v err=%v", u, item, err)
+		}
+		if err := store.SavePageError(item.ID, et, "boom"); err != nil {
+			t.Fatalf("SavePageError(%s): %v", u, err)
+		}
+	}
+
+	// Only the transient network_error is eligible.
+	items, err := store.GetRetryablePages(3)
+	if err != nil {
+		t.Fatalf("GetRetryablePages: %v", err)
+	}
+	if len(items) != 1 || items[0].URL != "https://example.com/net" {
+		t.Errorf("retryable = %+v, want exactly the network_error page", items)
+	}
+
+	requeued, err := store.RequeueErrorPages(3)
+	if err != nil {
+		t.Fatalf("RequeueErrorPages: %v", err)
+	}
+	if requeued != 1 {
+		t.Errorf("requeued = %d, want 1", requeued)
+	}
+	if got := mustStatus(t, store, "https://example.com/net"); got != "pending" {
+		t.Errorf("network_error page status = %q, want pending (requeued)", got)
+	}
+	for _, u := range []string{"https://example.com/proc", "https://example.com/rate", "https://example.com/big"} {
+		if got := mustStatus(t, store, u); got != "error" {
+			t.Errorf("%s status = %q, want error (deterministic failures must not requeue)", u, got)
+		}
+	}
+}
+
+// Timestamps must be stored in the fixed-width UTC layout so string comparison
+// in SQL matches chronological order regardless of local timezone/DST.
+func TestTimestampsStoredInFixedWidthUTC(t *testing.T) {
+	store := newTempStorage(t)
+	if err := store.AddToQueue([]string{"https://example.com/ts"}); err != nil {
+		t.Fatalf("AddToQueue: %v", err)
+	}
+
+	// CAST(...) makes the expression lose the column's DATETIME declared type,
+	// so the driver returns the raw stored TEXT instead of parsing it into a
+	// time.Time and re-formatting (which would trim trailing zeros).
+	var added string
+	if err := store.db.QueryRow(
+		"SELECT CAST(added_at AS TEXT) FROM pages WHERE url = 'https://example.com/ts'",
+	).Scan(&added); err != nil {
+		t.Fatalf("select added_at: %v", err)
+	}
+
+	parsed, err := time.Parse(sqlTimeFormat, added)
+	if err != nil {
+		t.Fatalf("added_at %q does not match sqlTimeFormat: %v", added, err)
+	}
+	if d := time.Since(parsed); d < 0 || d > time.Minute {
+		t.Errorf("added_at %q not near now (delta %v)", added, d)
+	}
+	// Fixed width is what keeps lexicographic order == chronological order.
+	if len(added) != len(sqlTimeFormat) {
+		t.Errorf("added_at %q is not fixed-width (len %d, want %d)", added, len(added), len(sqlTimeFormat))
+	}
+}

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -546,11 +546,18 @@ func (s *SQLiteStorage) RequeueErrorPages(maxRetries int) (int, error) {
 }
 
 // CleanupStaleProcessing resets processing items that have been stuck back to
-// 'pending'. A row with a NULL processing_started_at is always reset: `NULL < ?`
-// is never true in SQL, so without the explicit IS NULL clause such a row would
-// survive cleanup and keep HasQueuedItems() perpetually true, hanging the
-// crawler. The timestamp should never be NULL on the normal path, but the
-// invariant is cheap to enforce here.
+// 'pending'. Three clauses cover three row shapes that must all be reset:
+//   - processing_started_at < cutoff: normal stale rows in the current
+//     sqlTimeFormat ("YYYY-MM-DDT…Z"), where string order == time order.
+//   - IS NULL: `NULL < ?` is never true in SQL, so without the explicit
+//     clause an anomalous NULL row would survive forever and keep
+//     HasQueuedItems() true, hanging the crawler.
+//   - NOT LIKE '____-__-__T%': rows written by older releases, which stored
+//     Go's local-timezone time.String() form ("YYYY-MM-DD hh:mm:ss +0900 JST").
+//     Those strings do not compare meaningfully against a UTC cutoff (a local
+//     date can be ahead of the UTC date), so any row not in the current
+//     format is treated as stale outright — by definition it predates this
+//     process.
 func (s *SQLiteStorage) CleanupStaleProcessing(timeout time.Duration) error {
 	cutoff := sqlTime(time.Now().Add(-timeout))
 
@@ -558,7 +565,9 @@ func (s *SQLiteStorage) CleanupStaleProcessing(timeout time.Duration) error {
 		UPDATE pages
 		SET status = 'pending', processing_started_at = NULL
 		WHERE status = 'processing'
-		AND (processing_started_at < ? OR processing_started_at IS NULL)
+		AND (processing_started_at < ?
+		     OR processing_started_at IS NULL
+		     OR processing_started_at NOT LIKE '____-__-__T%')
 	`, cutoff)
 
 	if err != nil {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -6,12 +6,28 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/masahif/linktadoru/internal/crawler"
 	// SQLite database driver (CGO-free)
 	_ "modernc.org/sqlite"
 )
+
+// sqlTimeFormat is the layout used for every timestamp written to the database.
+// It is UTC with a FIXED-WIDTH fractional second so that SQLite's string
+// comparison (`processing_started_at < ?`, `ORDER BY added_at`) matches
+// chronological order regardless of the machine's timezone or DST changes.
+// time.RFC3339Nano is unsuitable here: it trims trailing zeros, which breaks
+// lexicographic ordering ("...11.1Z" sorts after "...11.10001Z").
+const sqlTimeFormat = "2006-01-02T15:04:05.000000000Z"
+
+// sqlTime formats a timestamp for storage. Always bind times through this
+// helper instead of passing time.Time to the driver, which would store Go's
+// timezone-dependent time.String() form.
+func sqlTime(t time.Time) string {
+	return t.UTC().Format(sqlTimeFormat)
+}
 
 // SQLiteStorage implements the Storage interface using SQLite
 type SQLiteStorage struct {
@@ -125,7 +141,7 @@ func (s *SQLiteStorage) AddToQueue(urls []string) error {
 		}
 	}()
 
-	now := time.Now()
+	now := sqlTime(time.Now())
 	for _, url := range urls {
 		if _, err := stmt.Exec(url, now); err != nil {
 			return fmt.Errorf("failed to insert URL %s: %w", url, err)
@@ -149,7 +165,7 @@ func (s *SQLiteStorage) GetNextFromQueue() (*crawler.URLItem, error) {
 			LIMIT 1
 		) AND status = 'pending'
 		RETURNING id, url
-	`, time.Now()).Scan(&item.ID, &item.URL)
+	`, sqlTime(time.Now())).Scan(&item.ID, &item.URL)
 
 	if err == sql.ErrNoRows {
 		return nil, nil // No items in queue
@@ -213,7 +229,7 @@ func (s *SQLiteStorage) SavePageResult(id int, page *crawler.PageData) error {
 		page.DownloadTime.Milliseconds(),
 		page.ResponseSize,
 		string(headersJSON),
-		page.CrawledAt,
+		sqlTime(page.CrawledAt),
 		id,
 	)
 
@@ -282,7 +298,7 @@ func (s *SQLiteStorage) SaveLink(link *crawler.LinkData) error {
 		link.AnchorText,
 		link.LinkType,
 		link.RelAttribute,
-		link.CrawledAt,
+		sqlTime(link.CrawledAt),
 	)
 
 	if err != nil {
@@ -351,7 +367,7 @@ func (s *SQLiteStorage) saveLinksBatch(links []*crawler.LinkData) error {
 		// for crawling, bypassing include/exclude filtering (issue #46).
 		result, err := tx.Exec(
 			"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'discovered', ?)",
-			url, time.Now(),
+			url, sqlTime(time.Now()),
 		)
 		if err != nil {
 			return fmt.Errorf("failed to insert page %s: %w", url, err)
@@ -401,7 +417,7 @@ func (s *SQLiteStorage) saveLinksBatch(links []*crawler.LinkData) error {
 			link.AnchorText,
 			link.LinkType,
 			link.RelAttribute,
-			link.CrawledAt,
+			sqlTime(link.CrawledAt),
 		); err != nil {
 			return fmt.Errorf("failed to insert link %s -> %s: %w", link.SourceURL, link.TargetURL, err)
 		}
@@ -422,7 +438,7 @@ func (s *SQLiteStorage) SaveError(crawlErr *crawler.CrawlError) error {
 		crawlErr.URL,
 		crawlErr.ErrorType,
 		crawlErr.ErrorMessage,
-		crawlErr.OccurredAt,
+		sqlTime(crawlErr.OccurredAt),
 	)
 
 	if err != nil {
@@ -466,14 +482,23 @@ func (s *SQLiteStorage) HasQueuedItems() (bool, error) {
 	return count > 0, nil
 }
 
+// retryableErrorTypes lists the last_error_type values eligible for retry.
+// These MUST match the strings the crawler actually writes via SavePageError:
+// 'network_error' (transient transport failure, see page_processor.go) is
+// worth retrying. Deliberately excluded: 'processing_error' and
+// 'rate_limit_error' (malformed URLs — retrying reproduces the same failure)
+// and 'response_too_large' (deterministic — the page will exceed the limit
+// again).
+const retryableErrorTypes = `('network_error')`
+
 // GetRetryablePages returns pages with error status that can be retried
 func (s *SQLiteStorage) GetRetryablePages(maxRetries int) ([]crawler.URLItem, error) {
 	rows, err := s.db.Query(`
-		SELECT id, url, retry_count, last_error_type 
-		FROM pages 
-		WHERE status = 'error' 
-		  AND retry_count < ? 
-		  AND last_error_type IN ('network_timeout', 'connection_refused', 'dns_resolution_failed', 'server_error_5xx')
+		SELECT id, url, retry_count, last_error_type
+		FROM pages
+		WHERE status = 'error'
+		  AND retry_count < ?
+		  AND last_error_type IN `+retryableErrorTypes+`
 		ORDER BY retry_count ASC, added_at ASC
 	`, maxRetries)
 	if err != nil {
@@ -502,11 +527,11 @@ func (s *SQLiteStorage) GetRetryablePages(maxRetries int) ([]crawler.URLItem, er
 // RequeueErrorPages moves error status pages back to pending for retry
 func (s *SQLiteStorage) RequeueErrorPages(maxRetries int) (int, error) {
 	result, err := s.db.Exec(`
-		UPDATE pages 
-		SET status = 'pending', processing_started_at = NULL 
-		WHERE status = 'error' 
-		  AND retry_count < ? 
-		  AND last_error_type IN ('network_timeout', 'connection_refused', 'dns_resolution_failed', 'server_error_5xx')
+		UPDATE pages
+		SET status = 'pending', processing_started_at = NULL
+		WHERE status = 'error'
+		  AND retry_count < ?
+		  AND last_error_type IN `+retryableErrorTypes+`
 	`, maxRetries)
 	if err != nil {
 		return 0, fmt.Errorf("failed to requeue error pages: %w", err)
@@ -520,38 +545,6 @@ func (s *SQLiteStorage) RequeueErrorPages(maxRetries int) (int, error) {
 	return int(rowsAffected), nil
 }
 
-// GetProcessingItems returns currently processing items
-func (s *SQLiteStorage) GetProcessingItems() ([]crawler.URLItem, error) {
-	query := `
-		SELECT id, url 
-		FROM pages 
-		WHERE status = 'processing' 
-		ORDER BY processing_started_at DESC
-	`
-
-	rows, err := s.db.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query processing items: %w", err)
-	}
-	defer func() {
-		if err := rows.Close(); err != nil {
-			// Log error but don't fail the operation
-			_ = err
-		}
-	}()
-
-	var items []crawler.URLItem
-	for rows.Next() {
-		var item crawler.URLItem
-		if err := rows.Scan(&item.ID, &item.URL); err != nil {
-			return nil, fmt.Errorf("failed to scan processing item: %w", err)
-		}
-		items = append(items, item)
-	}
-
-	return items, nil
-}
-
 // CleanupStaleProcessing resets processing items that have been stuck back to
 // 'pending'. A row with a NULL processing_started_at is always reset: `NULL < ?`
 // is never true in SQL, so without the explicit IS NULL clause such a row would
@@ -559,7 +552,7 @@ func (s *SQLiteStorage) GetProcessingItems() ([]crawler.URLItem, error) {
 // crawler. The timestamp should never be NULL on the normal path, but the
 // invariant is cheap to enforce here.
 func (s *SQLiteStorage) CleanupStaleProcessing(timeout time.Duration) error {
-	cutoff := time.Now().Add(-timeout)
+	cutoff := sqlTime(time.Now().Add(-timeout))
 
 	_, err := s.db.Exec(`
 		UPDATE pages
@@ -606,7 +599,9 @@ func (s *SQLiteStorage) GetURLStatus(url string) (status string, exists bool) {
 		return "", false
 	}
 	if err != nil {
-		// Log error but return false
+		// A real DB failure must not pass silently as "URL not found" — the
+		// caller would then re-queue a URL that may already be tracked.
+		slog.Error("Failed to query URL status", "url", url, "error", err)
 		return "", false
 	}
 	return status, true
@@ -628,7 +623,7 @@ func (s *SQLiteStorage) getOrCreatePageID(url string) (int, error) {
 	// 'pending') so it is not crawled unless AddToQueue promotes it (issue #46).
 	result, err := s.db.Exec(
 		"INSERT OR IGNORE INTO pages (url, status, added_at) VALUES (?, 'discovered', ?)",
-		url, time.Now(),
+		url, sqlTime(time.Now()),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("failed to insert page: %w", err)

--- a/internal/storage/sqlite_test.go
+++ b/internal/storage/sqlite_test.go
@@ -402,18 +402,6 @@ func testQueueStatusTracking(t *testing.T) {
 	_ = completed // Ignore for this test
 	_ = errors    // Ignore for this test
 
-	// Get processing items
-	processingItems, err := statusStorage.GetProcessingItems()
-	if err != nil {
-		t.Errorf("Failed to get processing items: %v", err)
-	}
-	if len(processingItems) != 1 {
-		t.Errorf("Expected 1 processing item, got %d", len(processingItems))
-	}
-	if processingItems[0].URL != nextItem.URL {
-		t.Errorf("Processing item URL mismatch: expected %s, got %s", nextItem.URL, processingItems[0].URL)
-	}
-
 	// Complete the item
 	err = statusStorage.UpdatePageStatus(nextItem.ID, "completed")
 	if err != nil {

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -9,9 +9,17 @@ user_agent: "LinkTadoru/1.0"       # User-Agent header (version will be dynamica
 ignore_robots_txt: false    # Whether to ignore robots.txt rules (default: respect robots.txt)
 follow_external_hosts: false # Whether to crawl external hosts (default: same-host only for safety)
 limit: 0                    # Stop after N pages (0 = unlimited)
+max_response_size: 10485760 # Max response body size in bytes (default: 10 MiB); larger pages are recorded as errors
 
 # Database configuration
 database_path: "./linktadoru.db"  # Path to SQLite database file
+
+# Logging configuration
+log_level: "info"           # Log level: debug, info, warn, error (default: info)
+log_console: true           # Log to console (default: true)
+log_file: ""                # Path to log file (empty = no file logging)
+log_max_size: 100           # Max log file size in MB before rotation (default: 100)
+log_max_backups: 5          # Number of rotated log files to keep (default: 5)
 
 # URL filtering patterns
 include_patterns: []         # Regex patterns for URLs to include (empty = include all)

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -4,7 +4,7 @@
 # Basic crawling settings (improved defaults)
 concurrency: 2              # Number of concurrent workers (default: 2, was 10)
 request_delay: 0.1           # Delay between requests in seconds (default: 0.1, was 1.0)
-request_timeout: 30.0        # HTTP request timeout in seconds
+request_timeout: "30s"       # HTTP request timeout (Go duration, e.g. "30s", "1m")
 user_agent: "LinkTadoru/1.0"       # User-Agent header (version will be dynamically set if not specified)
 ignore_robots_txt: false    # Whether to ignore robots.txt rules (default: respect robots.txt)
 follow_external_hosts: false # Whether to crawl external hosts (default: same-host only for safety)


### PR DESCRIPTION
## Summary

Project-wide audit of the codebase, docs, and infrastructure, fixing every verified finding. Three review passes (two adversarial subagent reviews with empirical probes, plus peer review requests) were applied; all findings from those reviews are fixed and regression-tested.

## Bug fixes

- **Retries never ran — two independent bugs.** (1) The retryable-error SQL filtered on error types nothing ever wrote (`network_timeout`, …), while the crawler writes `network_error`. (2) Even with matching types, `performRetries` was unreachable: the last exiting worker cancelled the crawl context (to stop the stats reporter), so `Start` always took its "cancelled" branch. The stats reporter now has its own lifecycle, `Start` distinguishes natural completion from cancellation, and a dead seed now ends a run with `retry_count=2` (initial attempt + one retry pass), asserted by a new integration test.
- **Unbounded response reads (OOM risk).** Bodies are read through `io.LimitReader`; new `max_response_size` config / `--max-response-size` flag (default 10 MiB). Oversized pages are recorded as deterministic `response_too_large` errors and never retried.
- **Invalid `include_patterns`/`exclude_patterns` were silently ignored** (`regexp.MatchString` errors discarded — the same "configured but ineffective" failure mode as #46). Patterns are compiled once at startup; an invalid regex aborts the run with a clear message. Also removes per-URL recompilation.
- **Timezone-fragile timestamps.** All timestamps are stored in a fixed-width UTC layout so SQL string comparison matches chronological order across TZ/DST changes. `CleanupStaleProcessing` treats legacy-format rows (old releases stored Go's local-time `String()` form) as stale outright — a legacy row whose local date is ahead of the UTC cutoff would otherwise survive and hang the resume.
- **URL fragments** (`#section`) are stripped from discovered links — no more duplicate rows/crawls for anchor variants.
- **Graceful shutdown.** SIGINT/SIGTERM cancel the crawl context; `Start` always waits for its workers; the crawl database is now actually closed (it never was, on any path). A fetch aborted by cancellation is no longer recorded as a page error.

## Behavior improvements

- robots.txt `Crawl-delay` is honored (was parsed but never used), capped at `max(request_delay, 60s)` so a hostile value cannot park a domain; the per-domain rate limiter is idempotent so re-applying a delay doesn't reset its token bucket.
- robots.txt fetch failures (fail-open) and malformed `Crawl-delay` values are logged; `GetURLStatus` DB errors are logged instead of masquerading as "URL not found".
- Removed dead `GetProcessingItems` API.

## Docs & infrastructure

- Fixed copy-paste-breaking drift: `ignore_robots` → `ignore_robots_txt`, `--ignore-robots` → `--ignore-robots-txt`, `LT_IGNORE_ROBOTS` → `LT_IGNORE_ROBOTS_TXT` across README (en/ja), basic-usage (en/ja), configuration.md.
- technical-specification (en/ja): status lifecycle updated to the implemented `discovered → pending → processing → completed/skipped/error`.
- configuration.md gains missing `follow_external_hosts` and new `max_response_size`; `linktadoru.yml.example` documents the logging keys.
- Added `CHANGELOG.md` and `.github/dependabot.yml`; removed the reference to a nonexistent CODE_OF_CONDUCT.md.

## Testing

- New regression tests: retry eligibility matches written error types; retry phase actually runs (retry_count assertion); size limit boundary + `response_too_large` classification; invalid-pattern rejection; fragment stripping; rate-limiter idempotence; crawl-delay wiring; fixed-width UTC storage; legacy-format timestamp reset; prompt return on cancellation.
- `go build / vet / gofmt / test -race ./...` green; gocyclo gate clean.
- Adversarial re-verification confirmed each fix empirically (fail-once-then-succeed probe now ends `completed` 5/5; four legacy timestamp shapes all reset; 10x stress under `-race` with no flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
