### PR TITLE
docs: overhaul — fix drift, fill gaps, deduplicate into single sources of truth

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Configuration**
-Please provide your configuration file (config.yaml) or relevant parts of it:
+Please provide your configuration file (linktadoru.yml) or relevant parts of it:
 ```yaml
 # Your configuration here
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,9 +23,6 @@ Brief description of changes
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
 
 ## Screenshots (if appropriate)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,10 +3,11 @@
 This project uses the following workflows:
 
 ## CI (ci.yml)
-**Triggers**: 
-- Pull requests to main branch
-- Push to develop branch
+**Triggers**:
+- Pull requests to `main` (documentation-only changes are skipped via `paths-ignore`: `**.md`, `docs/**`, `LICENSE`, `.gitignore`)
 - Manual execution (workflow_dispatch)
+
+Note: direct pushes to `main` do not trigger CI. Run it manually when needed: `gh workflow run CI --ref main`.
 
 **Purpose**: Daily development quality checks
 - Test execution
@@ -16,36 +17,22 @@ This project uses the following workflows:
 
 ## Release (release.yml)
 **Triggers**: 
-- Push of v* tags (e.g., v1.0.0)
+- Push of `v*` tags (e.g., `v1.0.0`)
 
 **Purpose**: Final validation and binary build for releases
 - Test execution (final confirmation)
-- Multi-platform builds (Linux, macOS, Windows)
+- Multi-platform builds (Linux amd64/arm64, macOS arm64, Windows amd64)
 - Automatic GitHub Release creation
 - Release notes generation
 
 ## Local Testing (act)
 
-You can test GitHub Actions locally using act:
-
-```bash
-# Install act (macOS)
-brew install act
-
-# Run CI workflow locally
-act -W .github/workflows/ci.yml
-
-# Run specific job only
-act -W .github/workflows/ci.yml -j test
-
-# Debug mode
-act -W .github/workflows/ci.yml --verbose
-```
+See [docs/github-actions-local-testing.md](../../docs/github-actions-local-testing.md) for running these workflows locally with act.
 
 ## Recommended Workflow
 
-1. **Development**: Work on develop branch → CI runs automatically
-2. **Pull Request**: Create PR to main → CI runs automatically  
-3. **Release**: Create tag → Release workflow runs automatically
+1. **Development**: Work on a feature branch
+2. **Pull Request**: Create PR to `main` → CI runs automatically
+3. **Release**: Push a `v*` tag → Release workflow runs automatically
 
-This approach avoids unnecessary CI execution on direct pushes to main branch, running complete tests and builds only during releases.
+This approach avoids unnecessary CI execution on direct pushes to `main`, running complete tests and builds only for PRs and releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Documentation overhaul (no code changes):
+  - Deduplicated content into single sources of truth: the options table in
+    `docs/configuration.md` (config/auth/headers), `.github/workflows/README.md`
+    (CI/release triggers), `docs/versioning-and-releases.md` (release process),
+    and `docs/development.md` (build/test setup, project structure).
+  - Fixed factual drift: numeric `--delay`/`request_delay` values instead of
+    invalid duration strings, `LT_` environment variables documented as
+    flag-bound only (`log_*`/`allowed_schemes` are config-file only), release
+    artifact names without version suffix and including Linux ARM64, removed
+    nonexistent `.sha256`/`develop`-branch/`.actrc` claims, forbidden header
+    list corrected, and the retry mechanism described as it is implemented
+    (post-crawl requeue of `network_error` pages, 3 attempts, no backoff).
+  - Replaced the schema SQL dump in the technical specification with a pointer
+    to `internal/storage/schema.go` plus the design rationale (unified pages
+    table, JSON headers with generated columns, views).
+  - Documented crawl behavior in `docs/basic-usage(.ja).md`: page status
+    lifecycle, retries, robots.txt `Crawl-delay` handling, and safe
+    interrupt/resume.
+  - Completed the `docs/README(.ja).md` index and added a Logging section to
+    `docs/configuration.md`. All changes mirrored across English/Japanese pairs.
+
 ## [0.9.0] - 2026-07-03
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,49 +48,20 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 5. Make sure your code lints.
 6. Issue that pull request!
 
-### Prerequisites
+### Development Environment
 
-* Go 1.23 or higher
-* golangci-lint (for linting)
-* Make (optional, for using Makefile commands)
-
-### Setting up your development environment
+Prerequisites, build/test/lint commands, the project structure, and local CI testing are documented in the [Development Guide](docs/development.md). Quick start:
 
 ```bash
-# Clone your fork
+# Clone your fork and add upstream
 git clone https://github.com/your-username/linktadoru.git
 cd linktadoru
-
-# Add upstream remote
 git remote add upstream https://github.com/masahif/linktadoru.git
 
-# Install dependencies
-go mod download
-
-# Run tests
-go test ./...
-
-# Run linter
-golangci-lint run
-
-# Build the project
+# Build, test, lint
 make build
-```
-
-### Running Tests
-
-```bash
-# Run all tests
 make test
-
-# Run tests with coverage
-go test -cover ./...
-
-# Run tests for a specific package
-go test -v ./internal/crawler
-
-# Run benchmarks
-make bench
+make lint
 ```
 
 ### Code Style
@@ -119,22 +90,6 @@ Add concurrent crawling support
 Fixes #123
 ```
 
-## Project Structure
-
-```
-linktadoru/
-├── cmd/crawler/        # Main application entry point
-├── internal/          # Private application code
-│   ├── cmd/          # Command-line interface
-│   ├── config/       # Configuration handling
-│   ├── crawler/      # Core crawling logic
-│   ├── parser/       # HTML parsing
-│   └── storage/      # Data persistence
-├── .github/          # GitHub specific files
-├── docs/             # Documentation
-└── examples/         # Example configurations and usage
-```
-
 ## Testing Guidelines
 
 * Write table-driven tests where appropriate
@@ -152,10 +107,7 @@ linktadoru/
 
 ## Release Process
 
-1. All changes go through pull requests
-2. Maintainers review and merge PRs
-3. Releases are tagged following semantic versioning (v1.2.3)
-4. GitHub Actions automatically builds and publishes releases
+All changes go through pull requests reviewed by maintainers. Releases are tagged following semantic versioning and built automatically — see the [Versioning and Release Guide](docs/versioning-and-releases.md).
 
 ## Questions?
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,7 @@ Go言語で構築された高性能Webクローラーおよびリンク解析ツ
 - **複数の認証方式**: Basic認証、Bearerトークン、APIキーに対応
 - **カスタムHTTPヘッダー**: リクエスト用カスタムヘッダーの設定
 - **Robots.txt準拠**: robots.txtルールとクロール遅延を尊重
+- **安全なデフォルト**: シードホスト内に留まり（`follow_external_hosts: false`）、レスポンスボディを10 MiBに制限（`max_response_size`）
 - **SQLiteストレージ**: クエリ可能なSQLiteデータベースに全データを保存
 - **再開可能**: 中断されたセッション用の永続キュー
 - **柔軟な設定**: CLIフラグ、環境変数、または階層設定ファイル対応
@@ -78,20 +79,13 @@ request_delay: 0.1           # 秒
 user_agent: "LinkTadoru/1.0"
 ignore_robots_txt: false
 database_path: "./linktadoru.db"
-limit: 0                    # 0 = 無制限
+limit: 0                     # 0 = 無制限
 
 # URL フィルタリング
 include_patterns: []
 exclude_patterns:
-  - "\.pdf$"
+  - "\\.pdf$"
   - "/admin/.*"
-
-# 認証（いずれか一つの方法を選択）
-auth:
-  type: "basic"             # "basic"、"bearer"、または"api-key"
-  basic:
-    username: "user"
-    password: "pass"
 
 # カスタムHTTPヘッダー
 headers:
@@ -99,9 +93,11 @@ headers:
   - "X-Custom-Header: value"
 ```
 
+コメント付きの完全な設定例は [linktadoru.yml.example](linktadoru.yml.example) を、全オプションの一覧は[設定リファレンス](docs/configuration.md)（英語）を参照してください。
+
 ### 環境変数
 
-すべての設定は `LT_` プレフィックス付きの環境変数で設定可能です：
+CLIフラグを持つオプションは `LT_` プレフィックス付きの環境変数でも設定できます。ロギング設定（`log_*`）と `allowed_schemes` にはフラグがないため、設定ファイルでのみ指定可能です。
 
 ```bash
 # 基本設定
@@ -109,85 +105,25 @@ export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.5
 export LT_IGNORE_ROBOTS_TXT=true
 
-# 階層設定（アンダースコアを使用）
-export LT_AUTH_TYPE=basic
-export LT_AUTH_BASIC_USERNAME=myuser
-export LT_AUTH_BASIC_PASSWORD=mypass
-
-# HTTPヘッダー
+# HTTPヘッダー（LT_HEADER_* パターン）
 export LT_HEADER_ACCEPT="application/json"
-export LT_HEADER_X_CUSTOM="value"
 
 ./linktadoru https://httpbin.org
 ```
 
-## 認証
+## 認証とカスタムヘッダー
 
-LinkTadoruは保護されたリソースにアクセスするための複数の認証方式をサポートしています。
-
-### Basic認証
+Basic認証、Bearerトークン、APIキーの各認証方式と、全リクエストへのカスタムHTTPヘッダー設定に対応しています。例：
 
 ```bash
-# CLIフラグ
-./linktadoru --auth-type basic --auth-username user --auth-password pass https://protected.httpbin.org
-
-# 環境変数（推奨）
+# 環境変数（認証情報には推奨）
 export LT_AUTH_TYPE=basic
 export LT_AUTH_BASIC_USERNAME=myuser
 export LT_AUTH_BASIC_PASSWORD=mypass
-./linktadoru https://protected.httpbin.org
+./linktadoru -H "Accept: application/json" https://protected.example.com
 ```
 
-### Bearerトークン認証
-
-```bash
-# CLIフラグ
-./linktadoru --auth-type bearer --auth-token "your-bearer-token" https://api.example.com
-
-# 環境変数（推奨）
-export LT_AUTH_TYPE=bearer
-export LT_AUTH_BEARER_TOKEN=your-bearer-token-here
-./linktadoru https://api.example.com
-```
-
-### APIキー認証
-
-```bash
-# CLIフラグ
-./linktadoru --auth-type api-key --auth-header "X-API-Key" --auth-value "your-key" https://api.example.com
-
-# 環境変数（推奨）
-export LT_AUTH_TYPE=api-key
-export LT_AUTH_APIKEY_HEADER=X-API-Key
-export LT_AUTH_APIKEY_VALUE=your-api-key-here
-./linktadoru https://api.example.com
-```
-
-### 設定ファイル
-
-```yaml
-# linktadoru.yml
-auth:
-  type: "bearer"
-  bearer:
-    token: "your-token-here"
-    # または環境変数を使用:
-    # token_env: "MY_BEARER_TOKEN"
-```
-
-## カスタムHTTPヘッダー
-
-すべてのリクエストにカスタムHTTPヘッダーを設定：
-
-```bash
-# CLIフラグ
-./linktadoru -H "Accept: application/json" -H "X-Custom: value" https://api.example.com
-
-# 環境変数
-export LT_HEADER_ACCEPT="application/json"
-export LT_HEADER_X_API_VERSION="v1"
-./linktadoru https://api.example.com
-```
+すべての認証方式（CLIフラグ・環境変数・設定ファイル）とヘッダーオプションについては、[設定リファレンス — Authentication](docs/configuration.md#authentication)（英語）を参照してください。
 
 **セキュリティ注意事項**: セキュリティ上の理由から、設定ファイルに認証情報を保存するのではなく、環境変数を使用することを推奨します。
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A high-performance web crawler and link analysis tool built in Go.
 - **Multiple Authentication Methods**: Support for Basic Auth, Bearer tokens, and API keys
 - **Custom HTTP Headers**: Set custom headers for requests
 - **Robots.txt Compliance**: Respects robots.txt rules and crawl delays
+- **Safe by Default**: Stays on the seed hosts (`follow_external_hosts: false`) and caps response bodies at 10 MiB (`max_response_size`)
 - **SQLite Storage**: All data stored in a queryable SQLite database
 - **Resumable**: Persistent queue for interrupted sessions
 - **Flexible Configuration**: CLI flags, environment variables, or config file with hierarchical support
@@ -78,20 +79,13 @@ request_delay: 0.1           # seconds
 user_agent: "LinkTadoru/1.0"
 ignore_robots_txt: false
 database_path: "./linktadoru.db"
-limit: 0                    # 0 = unlimited
+limit: 0                     # 0 = unlimited
 
 # URL filtering
 include_patterns: []
 exclude_patterns:
-  - "\.pdf$"
+  - "\\.pdf$"
   - "/admin/.*"
-
-# Authentication (choose one method)
-auth:
-  type: "basic"             # "basic", "bearer", or "api-key"
-  basic:
-    username: "user"
-    password: "pass"
 
 # Custom HTTP headers
 headers:
@@ -99,9 +93,11 @@ headers:
   - "X-Custom-Header: value"
 ```
 
+See [linktadoru.yml.example](linktadoru.yml.example) for a complete annotated example and the [Configuration Reference](docs/configuration.md) for every option.
+
 ### Environment Variables
 
-All configuration can be set via environment variables with `LT_` prefix:
+Options that have a CLI flag can also be set via environment variables with the `LT_` prefix. Logging options (`log_*`) and `allowed_schemes` have no flags and can only be set in the configuration file.
 
 ```bash
 # Basic settings
@@ -109,85 +105,25 @@ export LT_CONCURRENCY=2
 export LT_REQUEST_DELAY=0.5
 export LT_IGNORE_ROBOTS_TXT=true
 
-# Hierarchical settings (using underscores)
-export LT_AUTH_TYPE=basic
-export LT_AUTH_BASIC_USERNAME=myuser
-export LT_AUTH_BASIC_PASSWORD=mypass
-
-# HTTP headers
+# HTTP headers (LT_HEADER_* pattern)
 export LT_HEADER_ACCEPT="application/json"
-export LT_HEADER_X_CUSTOM="value"
 
 ./linktadoru https://httpbin.org
 ```
 
-## Authentication
+## Authentication and Custom Headers
 
-LinkTadoru supports multiple authentication methods for accessing protected resources.
-
-### Basic Authentication
+LinkTadoru supports Basic Auth, Bearer tokens, and API keys, plus custom HTTP headers for all requests. Example:
 
 ```bash
-# CLI flags
-./linktadoru --auth-type basic --auth-username user --auth-password pass https://protected.httpbin.org
-
-# Environment variables (recommended)
+# Environment variables (recommended for credentials)
 export LT_AUTH_TYPE=basic
 export LT_AUTH_BASIC_USERNAME=myuser
 export LT_AUTH_BASIC_PASSWORD=mypass
-./linktadoru https://protected.httpbin.org
+./linktadoru -H "Accept: application/json" https://protected.example.com
 ```
 
-### Bearer Token Authentication
-
-```bash
-# CLI flags
-./linktadoru --auth-type bearer --auth-token "your-bearer-token" https://api.example.com
-
-# Environment variables (recommended)
-export LT_AUTH_TYPE=bearer
-export LT_AUTH_BEARER_TOKEN=your-bearer-token-here
-./linktadoru https://api.example.com
-```
-
-### API Key Authentication
-
-```bash
-# CLI flags
-./linktadoru --auth-type api-key --auth-header "X-API-Key" --auth-value "your-key" https://api.example.com
-
-# Environment variables (recommended)
-export LT_AUTH_TYPE=api-key
-export LT_AUTH_APIKEY_HEADER=X-API-Key
-export LT_AUTH_APIKEY_VALUE=your-api-key-here
-./linktadoru https://api.example.com
-```
-
-### Configuration File
-
-```yaml
-# linktadoru.yml
-auth:
-  type: "bearer"
-  bearer:
-    token: "your-token-here"
-    # Or use environment variable:
-    # token_env: "MY_BEARER_TOKEN"
-```
-
-## Custom HTTP Headers
-
-Set custom HTTP headers for all requests:
-
-```bash
-# CLI flags
-./linktadoru -H "Accept: application/json" -H "X-Custom: value" https://api.example.com
-
-# Environment variables
-export LT_HEADER_ACCEPT="application/json"
-export LT_HEADER_X_API_VERSION="v1"
-./linktadoru https://api.example.com
-```
+See [Configuration Reference — Authentication](docs/configuration.md#authentication) for all methods (CLI flags, environment variables, config file) and header options.
 
 **Security Note**: For security reasons, it's recommended to use environment variables rather than storing credentials in configuration files.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,9 @@ We release patches for security vulnerabilities. Which versions are eligible for
 
 The LinkTadoru team and community take all security bugs seriously. Thank you for improving the security of our project. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs by creating a private security advisory on GitHub or by creating an issue marked with the "security" label.
+Report security bugs privately via GitHub's private vulnerability reporting: go to the repository's **Security** tab and choose **Report a vulnerability**. Please do not open a public issue for security bugs.
 
-The lead maintainer will acknowledge your email within 48 hours, and will send a more detailed response within 48 hours indicating the next steps in handling your report. After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+The lead maintainer will acknowledge your report within 48 hours, and will send a more detailed response within a further 48 hours indicating the next steps in handling your report. After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
 Please report security bugs in third-party modules to the person or team maintaining the module.
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -1,37 +1,24 @@
 # LinkTadoru ドキュメント
 
-このディレクトリには、LinkTadoruの包括的なドキュメントが含まれています。
+このディレクトリには、LinkTadoruのドキュメントが含まれています。LinkTadoruが初めての方は、[基本的な使用例](basic-usage.ja.md)から始め、次に[設定リファレンス](configuration.md)（英語）を参照してください。
 
-## 📚 利用可能なドキュメント
+## ユーザーガイド
 
-### ユーザーガイド
-- **[基本的な使用例](basic-usage.ja.md)** - コマンドライン使用法、設定、トラブルシューティング
-- **[Basic Usage Examples](basic-usage.md)** - Command-line usage, configuration, and troubleshooting (English)
+- **[基本的な使用例](basic-usage.ja.md)** - コマンドライン使用法、クロールの挙動、トラブルシューティング
+- **[Basic Usage Examples](basic-usage.md)** - Command-line usage, crawl behavior, and troubleshooting (English)
+- **[設定リファレンス](configuration.md)** - すべての設定オプション（英語。コメント付き設定例は [linktadoru.yml.example](../linktadoru.yml.example) を参照）
 
-### 技術ドキュメント  
+## 技術ドキュメント
+
 - **[技術仕様書](technical-specification.ja.md)** - アーキテクチャ、実装詳細、設計判断
 - **[Technical Specification](technical-specification.md)** - Architecture, implementation details, and design decisions (English)
 
-### 設定
-- **[設定リファレンス](../linktadoru.yml.example)** - 完全な設定オプションと例
+## 開発とリリース
 
-## 🚀 クイックスタート
+- **[開発ガイド](development.md)** - ビルド、テスト、開発環境（英語）
+- **[バージョニングとリリースガイド](versioning-and-releases.md)** - リリースプロセスと成果物（英語）
+- **[GitHub Actionsローカルテスト](github-actions-local-testing.md)** - actによるCIのローカル実行（英語）
 
-LinkTadoruが初めてですか？ここから始めてください：
-
-1. コマンドライン使用法について [基本的な使用例](basic-usage.ja.md) を読む
-2. セットアップオプションについて [設定リファレンス](../linktadoru.yml.example) を確認
-3. より詳細な情報が必要な場合は [技術仕様書](technical-specification.ja.md) を参照
-
-## 🏗️ アーキテクチャ
-
-開発者と貢献者向けに、[技術仕様書](technical-specification.ja.md) では以下の詳細情報を提供しています：
-
-- システムアーキテクチャとコンポーネント
-- データベーススキーマと設計
-- パフォーマンスの考慮事項
-- テスト戦略
-
-## 📝 ドキュメントへの貢献
+## ドキュメントへの貢献
 
 ドキュメントの改善を歓迎します！プロジェクトへの貢献に関するガイドラインについては、[../CONTRIBUTING.md](../CONTRIBUTING.md) をご覧ください。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,37 +1,24 @@
 # LinkTadoru Documentation
 
-This directory contains comprehensive documentation for LinkTadoru.
+This directory contains the documentation for LinkTadoru. New to LinkTadoru? Start with the [Basic Usage Examples](basic-usage.md), then the [Configuration Reference](configuration.md).
 
-## 📚 Available Documentation
+## User Guides
 
-### User Guides
-- **[Basic Usage Examples](basic-usage.md)** - Command-line usage, configuration, and troubleshooting
-- **[基本的な使用例](basic-usage.ja.md)** - コマンドライン使用法、設定、トラブルシューティング（日本語）
+- **[Basic Usage Examples](basic-usage.md)** - Command-line usage, crawl behavior, and troubleshooting
+- **[基本的な使用例](basic-usage.ja.md)** - コマンドライン使用法、クロールの挙動、トラブルシューティング（日本語）
+- **[Configuration Reference](configuration.md)** - All configuration options (see also [linktadoru.yml.example](../linktadoru.yml.example) for an annotated config file)
 
-### Technical Documentation  
+## Technical Documentation
+
 - **[Technical Specification](technical-specification.md)** - Architecture, implementation details, and design decisions
-- **[Technical Specification (Japanese)](technical-specification.ja.md)** - 技術仕様書（日本語）
+- **[技術仕様書](technical-specification.ja.md)** - アーキテクチャ、実装詳細、設計判断（日本語）
 
-### Configuration
-- **[Configuration Reference](../linktadoru.yml.example)** - Complete configuration options and examples
+## Development and Releases
 
-## 🚀 Quick Start
+- **[Development Guide](development.md)** - Building, testing, and development environments
+- **[Versioning and Release Guide](versioning-and-releases.md)** - Release process and artifacts
+- **[GitHub Actions Local Testing](github-actions-local-testing.md)** - Running CI locally with act
 
-New to LinkTadoru? Start here:
-
-1. Read the [Basic Usage Examples](basic-usage.md) for command-line usage
-2. Check the [Configuration Reference](../linktadoru.yml.example) for setup options
-3. Explore the [Technical Specification](technical-specification.md) for detailed architecture information
-
-## 🏗️ Architecture
-
-For developers and contributors, the [Technical Specification](technical-specification.md) provides detailed information about:
-
-- System architecture and components
-- Database schema and design
-- Performance considerations
-- Testing strategies
-
-## 📝 Contributing to Documentation
+## Contributing to Documentation
 
 Documentation improvements are welcome! See [../CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on contributing to the project.

--- a/docs/basic-usage.ja.md
+++ b/docs/basic-usage.ja.md
@@ -14,10 +14,10 @@
 
 ### 2. カスタム設定での制限付きクロール
 
-2つの並行ワーカーで最大10ページをクロール：
+2つの並行ワーカー・2秒間隔で最大10ページをクロール（`--delay`は秒数を数値で指定）：
 
 ```bash
-./linktadoru --limit 10 --concurrency 2 --delay 2s https://httpbin.org
+./linktadoru --limit 10 --concurrency 2 --delay 2 https://httpbin.org
 ```
 
 ### 3. 設定ファイルの使用
@@ -27,15 +27,15 @@
 ```yaml
 # mysite-config.yml
 concurrency: 3
-request_delay: 1s
-request_timeout: 15s
+request_delay: 1             # 秒（数値）
+request_timeout: "15s"       # Go duration文字列
 user_agent: "MyBot/1.0"
 ignore_robots_txt: false
 limit: 50
 database_path: "./mysite-crawl.db"
 
 include_patterns:
-  - "^https?://[^/]*httpbin\.org/.*"
+  - "^https?://[^/]*httpbin\\.org/.*"
 
 exclude_patterns:
   - "\\.pdf$"
@@ -81,7 +81,7 @@ LinkTadoruは既存のデータベースから自動的に再開します：
 ./linktadoru \
   --ignore-robots-txt \
   --concurrency 20 \
-  --delay 500ms \
+  --delay 0.5 \
   https://httpbin.org
 ```
 
@@ -96,6 +96,30 @@ LinkTadoruは既存のデータベースから自動的に再開します：
   https://httpbin.org
 ```
 
+## クロールの挙動
+
+### ページステータスのライフサイクル
+
+各URLは`pages`テーブルの1行に対応し、`status`カラムがライフサイクルを表します：
+
+- `discovered` — クロール済みページ上でリンクとして発見された状態。リンク解析用に記録されるだけで、クロール対象にはならない
+- `pending` — クロール待ち（シードURL、およびinclude/excludeフィルタを通過した発見リンク）
+- `processing` — ワーカーが取得処理中
+- `completed` — 取得が完了した状態。注意: 404などのHTTPエラーも`completed`になります。結果は`status_code`カラムで確認してください
+- `skipped` — robots.txtによりブロック
+- `error` — 取得に失敗した状態。トランスポートレベルの失敗（DNS、タイムアウト、接続リセット）のほか、`max_response_size`超過や不正なURLも含まれます
+
+### リトライ
+
+キューが空になった後、`last_error_type`が`network_error`のページのみが再キューされ、1回の実行につき1リトライパスが行われます。URLごとの試行回数は`retry_count`で管理され、合計3回までです。決定的な失敗はリトライされません。
+
+### robots.txtのCrawl-delay
+
+robots.txtの`Crawl-delay`は、設定した`request_delay`より遅い場合にのみ適用されます。クロールを遅くする方向にしか働かず（速くなることはありません）、上限は60秒です。
+
+### 中断と再開
+
+Ctrl-C（SIGINT/SIGTERM）で安全に停止できます。処理中の状態は永続化され、データベースは正常にクローズされます。同じ`--database`を指定して再実行すれば再開でき、`processing`のまま残った行は次回起動時に自動的に再キューされます。
 
 ## 出力の分析
 
@@ -134,27 +158,7 @@ sqlite3 -header -csv linktadoru.db "SELECT * FROM links;" > links.csv
 
 ## パフォーマンスチューニング
 
-### 大規模サイト向け
-
-```yaml
-# high-performance.yaml
-concurrency: 50
-request_delay: 100ms
-request_timeout: 10s
-user_agent: "FastCrawler/1.0"
-limit: 0  # 無制限
-```
-
-### 礼儀正しいクロール
-
-```yaml
-# respectful.yaml
-concurrency: 2
-request_delay: 5s
-request_timeout: 30s
-ignore_robots_txt: false
-user_agent: "PoliteBot/1.0"
-```
+サイト規模別の推奨設定と礼儀正しいクロールについては、[設定リファレンス — Performance Tuning](configuration.md#performance-tuning)（英語）を参照してください。
 
 ## トラブルシューティング
 

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -14,10 +14,10 @@ Crawl a single website with default settings:
 
 ### 2. Limited Crawl with Custom Settings
 
-Crawl up to 10 pages with 2 concurrent workers:
+Crawl up to 10 pages with 2 concurrent workers and a 2-second delay (`--delay` takes seconds as a number):
 
 ```bash
-./linktadoru --limit 10 --concurrency 2 --delay 2s https://httpbin.org
+./linktadoru --limit 10 --concurrency 2 --delay 2 https://httpbin.org
 ```
 
 ### 3. Using Configuration File
@@ -27,15 +27,15 @@ Create a configuration file:
 ```yaml
 # mysite-config.yml
 concurrency: 3
-request_delay: 1s
-request_timeout: 15s
+request_delay: 1             # seconds (number)
+request_timeout: "15s"       # Go duration string
 user_agent: "MyBot/1.0"
 ignore_robots_txt: false
 limit: 50
 database_path: "./mysite-crawl.db"
 
 include_patterns:
-  - "^https?://[^/]*httpbin\.org/.*"
+  - "^https?://[^/]*httpbin\\.org/.*"
 
 exclude_patterns:
   - "\\.pdf$"
@@ -81,7 +81,7 @@ LinkTadoru automatically resumes from existing database:
 ./linktadoru \
   --ignore-robots-txt \
   --concurrency 20 \
-  --delay 500ms \
+  --delay 0.5 \
   https://httpbin.org
 ```
 
@@ -96,6 +96,30 @@ Crawl only blog posts and articles:
   https://httpbin.org
 ```
 
+## How Crawling Behaves
+
+### Page Status Lifecycle
+
+Every URL gets one row in the `pages` table; the `status` column tracks its lifecycle:
+
+- `discovered` — found as a link on a crawled page; recorded for link analysis only, not queued for crawling
+- `pending` — queued for crawling (seed URLs, and discovered links that pass the include/exclude filters)
+- `processing` — currently being fetched by a worker
+- `completed` — the fetch finished. Note: HTTP errors such as 404 are also `completed`; check the `status_code` column for the result
+- `skipped` — blocked by robots.txt
+- `error` — the fetch failed: transport-level failures (DNS, timeout, connection reset), a response body exceeding `max_response_size`, or a malformed URL
+
+### Retries
+
+After the queue drains, pages whose `last_error_type` is `network_error` are requeued for one retry pass per run, up to 3 attempts in total per URL (tracked in `retry_count`). Deterministic failures are not retried.
+
+### robots.txt Crawl-delay
+
+A `Crawl-delay` in robots.txt is honored when it is slower than your configured `request_delay`. It only ever slows crawling down (never speeds it up), and is capped at 60 seconds.
+
+### Interrupting and Resuming
+
+Ctrl-C (SIGINT/SIGTERM) stops the crawl gracefully: in-flight state is persisted and the database is closed cleanly. Rerun with the same `--database` to resume — rows left in `processing` are automatically requeued at the next start.
 
 ## Output Analysis
 
@@ -134,27 +158,7 @@ sqlite3 -header -csv linktadoru.db "SELECT * FROM links;" > links.csv
 
 ## Performance Tuning
 
-### For Large Sites
-
-```yaml
-# high-performance.yaml
-concurrency: 50
-request_delay: 100ms
-request_timeout: 10s
-user_agent: "FastCrawler/1.0"
-limit: 0  # unlimited
-```
-
-### For Respectful Crawling
-
-```yaml
-# respectful.yaml
-concurrency: 2
-request_delay: 5s
-request_timeout: 30s
-ignore_robots_txt: false
-user_agent: "PoliteBot/1.0"
-```
+See [Configuration Reference — Performance Tuning](configuration.md#performance-tuning) for recommended settings per site size and for respectful crawling.
 
 ## Troubleshooting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,82 +7,81 @@ LinkTadoru can be configured through multiple methods with the following priorit
 3. Configuration file (`linktadoru.yml`)
 4. Default values (lowest priority)
 
-## Command-Line Flags
+## Configuration Options
 
-```bash
-./linktadoru --help
+This table is the authoritative reference for all options. Run `./linktadoru --help` for the current flag list and `./linktadoru --show-config` to inspect the effective configuration.
 
-Flags:
-      --auth-header string         API key header name (e.g., X-API-Key)
-      --auth-password string       Password for basic authentication
-      --auth-token string          Bearer token for authorization header
-      --auth-type string           Authentication type: 'basic', 'bearer', or 'api-key'
-      --auth-username string       Username for basic authentication
-      --auth-value string          API key header value
-  -c, --concurrency int            Number of concurrent workers (default 2)
-      --config string              config file (default is ./linktadoru.yml)
-  -d, --database string            Path to SQLite database file (default "./linktadoru.db")
-  -r, --delay float                Delay between requests in seconds (default 0.1)
-      --exclude-patterns strings   Regex patterns for URLs to exclude
-  -H, --header strings             Custom HTTP headers in 'Name: Value' format (use multiple times for multiple headers)
-  -h, --help                       help for linktadoru
-      --ignore-robots-txt              Ignore robots.txt rules
-      --include-patterns strings   Regex patterns for URLs to include
-  -l, --limit int                  Stop after N pages (0=unlimited)
-      --show-config                Display current configuration in YAML format and exit
-  -t, --timeout duration           HTTP request timeout (default 30s)
-  -u, --user-agent string          HTTP User-Agent header (default "LinkTadoru/1.0")
-  -v, --version                    version for linktadoru
-```
+| Option | CLI Flag | Environment Variable | Default | Description |
+|--------|----------|---------------------|---------|-------------|
+| **Basic Settings** |
+| concurrency | `-c, --concurrency` | `LT_CONCURRENCY` | 2 | Number of concurrent workers |
+| request_delay | `-r, --delay` | `LT_REQUEST_DELAY` | 0.1 | Delay between requests in seconds (number) |
+| request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout (Go duration) |
+| user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
+| ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
+| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Allow crawling hosts other than the seed hosts |
+| limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
+| max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes (10 MiB) |
+| database_path | `-d, --database` | `LT_DATABASE_PATH` | ./linktadoru.db | SQLite database file path |
+| **URL Filtering** |
+| include_patterns | `--include-patterns` | `LT_INCLUDE_PATTERNS` | [] | URL patterns to include (regex) |
+| exclude_patterns | `--exclude-patterns` | `LT_EXCLUDE_PATTERNS` | [] | URL patterns to exclude (regex) |
+| allowed_schemes | - | - | ["https://", "http://"] | Allowed URL schemes (config file only) |
+| **Authentication** |
+| auth.type | `--auth-type` | `LT_AUTH_TYPE` | "" | Authentication type: basic, bearer, api-key |
+| auth.basic.username | `--auth-username` | `LT_AUTH_BASIC_USERNAME` | "" | Basic auth username |
+| auth.basic.password | `--auth-password` | `LT_AUTH_BASIC_PASSWORD` | "" | Basic auth password |
+| auth.bearer.token | `--auth-token` | `LT_AUTH_BEARER_TOKEN` | "" | Bearer token |
+| auth.apikey.header | `--auth-header` | `LT_AUTH_APIKEY_HEADER` | "" | API key header name |
+| auth.apikey.value | `--auth-value` | `LT_AUTH_APIKEY_VALUE` | "" | API key value |
+| **HTTP Headers** |
+| headers | `-H, --header` | `LT_HEADER_*` | [] | Custom HTTP headers |
+| **Logging** |
+| log_level | - | - | info | Log level: debug, info, warn, error (config file only) |
+| log_console | - | - | true | Log to console (config file only) |
+| log_file | - | - | "" | Path to log file, empty = no file logging (config file only) |
+| log_max_size | - | - | 100 | Max log file size in MB before rotation (config file only) |
+| log_max_backups | - | - | 5 | Number of rotated log files to keep (config file only) |
+| **Other** |
+| show_config | `--show-config` | - | false | Display current configuration and exit |
 
 ## Configuration File
 
-Create a `linktadoru.yml` file:
+Create a `linktadoru.yml` file (see [linktadoru.yml.example](../linktadoru.yml.example) for a complete annotated example):
 
 ```yaml
-# Basic crawling parameters (updated defaults)
-concurrency: 2              # Number of concurrent workers (default: 2, was 10)
-request_delay: 0.1           # Delay between requests in seconds (default: 0.1, was 1.0)
+# Basic crawling parameters
+concurrency: 2               # Number of concurrent workers
+request_delay: 0.1           # Delay between requests in seconds (number)
 request_timeout: "30s"       # HTTP request timeout (Go duration, e.g. "30s", "1m")
-user_agent: "LinkTadoru/1.0" # User-Agent header
-ignore_robots_txt: false        # Whether to ignore robots.txt rules
-limit: 0                    # Stop after N pages (0 = unlimited)
+user_agent: "LinkTadoru/1.0"
+ignore_robots_txt: false
+follow_external_hosts: false # Stay on the seed hosts by default
+limit: 0                     # Stop after N pages (0 = unlimited)
+max_response_size: 10485760  # Max response body size in bytes (10 MiB)
 
-# Authentication configuration
-auth:
-  type: ""                  # Authentication type: "", "basic", "bearer", or "api-key"
-  basic:
-    username: "user"        # Basic auth username
-    password: "pass"        # Basic auth password
-  bearer:
-    token: "your_token_here"  # Bearer token
-  apikey:
-    header: "X-API-Key"     # Header name for API key
-    value: "your_key_here"  # API key value
+# URL filtering (regex; double the backslashes in double-quoted YAML strings)
+include_patterns:
+  - "^https?://[^/]*httpbin\\.org/.*"
+exclude_patterns:
+  - "\\.pdf$"
+  - "/admin/.*"
 
 # Custom HTTP headers
 headers:
   - "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
   - "Accept-Language: en-us,en;q=0.5"
-  # Add custom headers as needed
 
-# URL filtering
-include_patterns:
-  - "^https?://[^/]*httpbin\.org/.*"
-  - "^https?://[^/]*subdomain\.httpbin\.org/.*"
-
-exclude_patterns:
-  - "\.pdf$"
-  - "/admin/.*"
-  - ".*#.*"
-
-# Storage configuration
+# Storage
 database_path: "./linktadoru.db"
+
+# Logging (config file only, see the Logging section)
+log_level: "info"
 ```
 
 ## Environment Variables
 
-All configuration options can be set via environment variables with the `LT_` prefix:
+Options that are bound to a CLI flag can be set via environment variables with the `LT_` prefix (see the table above). Options without a flag — the `log_*` keys, `allowed_schemes`, and `seed_urls` — cannot be set via environment variables; use the configuration file instead.
 
 ```bash
 # Basic configuration
@@ -94,21 +93,12 @@ export LT_IGNORE_ROBOTS_TXT=false
 export LT_DATABASE_PATH="./mysite.db"
 export LT_LIMIT=1000
 
-# Authentication (recommended method)
+# Authentication (recommended method, see Authentication below)
 export LT_AUTH_TYPE=basic
 export LT_AUTH_BASIC_USERNAME="myuser"
 export LT_AUTH_BASIC_PASSWORD="mypass"
 
-# Bearer token authentication
-export LT_AUTH_TYPE=bearer
-export LT_AUTH_BEARER_TOKEN="your-jwt-token"
-
-# API key authentication
-export LT_AUTH_TYPE=api-key
-export LT_AUTH_APIKEY_HEADER="X-API-Key"
-export LT_AUTH_APIKEY_VALUE="your-api-key"
-
-# Custom HTTP headers (hierarchical)
+# Custom HTTP headers (LT_HEADER_<NAME> pattern)
 export LT_HEADER_ACCEPT="application/json"
 export LT_HEADER_ACCEPT_LANGUAGE="en-US,en;q=0.9"
 export LT_HEADER_X_CUSTOM="MyCustomValue"
@@ -116,103 +106,69 @@ export LT_HEADER_X_CUSTOM="MyCustomValue"
 ./linktadoru https://httpbin.org
 ```
 
-## Configuration Options
+## Logging
 
-| Option | CLI Flag | Environment Variable | Default | Description |
-|--------|----------|---------------------|---------|-------------|
-| **Authentication** |
-| auth_type | `--auth-type` | `LT_AUTH_TYPE` | "" | Authentication type: basic, bearer, api-key |
-| auth_username | `--auth-username` | `LT_AUTH_BASIC_USERNAME` | "" | Basic auth username |
-| auth_password | `--auth-password` | `LT_AUTH_BASIC_PASSWORD` | "" | Basic auth password |
-| auth_token | `--auth-token` | `LT_AUTH_BEARER_TOKEN` | "" | Bearer token |
-| auth_header | `--auth-header` | `LT_AUTH_APIKEY_HEADER` | "" | API key header name |
-| auth_value | `--auth-value` | `LT_AUTH_APIKEY_VALUE` | "" | API key value |
-| **HTTP Headers** |
-| headers | `-H, --header` | `LT_HEADER_*` | [] | Custom HTTP headers |
-| **Basic Settings** |
-| concurrency | `-c, --concurrency` | `LT_CONCURRENCY` | 2 | Number of concurrent workers |
-| request_delay | `-r, --delay` | `LT_REQUEST_DELAY` | 0.1 | Delay between requests in seconds |
-| request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout |
-| user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
-| ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
-| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Allow crawling hosts other than the seed hosts |
-| limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
-| max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes |
-| database_path | `-d, --database` | `LT_DATABASE_PATH` | ./linktadoru.db | SQLite database file path |
-| **URL Filtering** |
-| include_patterns | `--include-patterns` | `LT_INCLUDE_PATTERNS` | [] | URL patterns to include (regex) |
-| exclude_patterns | `--exclude-patterns` | `LT_EXCLUDE_PATTERNS` | [] | URL patterns to exclude (regex) |
-| **Other** |
-| show_config | `--show-config` | - | false | Display current configuration and exit |
+Logging is configured in the configuration file only (no CLI flags or environment variables):
+
+```yaml
+log_level: "info"    # debug, info, warn, error (default: info)
+log_console: true    # Log to console (default: true)
+log_file: ""         # Path to log file; empty = no file logging
+log_max_size: 100    # Max log file size in MB before rotation (default: 100)
+log_max_backups: 5   # Number of rotated log files to keep (default: 5)
+```
 
 ## Authentication
 
-LinkTadoru supports multiple authentication methods for accessing password-protected websites:
+LinkTadoru supports multiple authentication methods for accessing password-protected websites. Only one method can be active at a time.
 
-- **Basic Authentication**: Standard HTTP Basic Auth with username/password
-- **Bearer Token**: Authorization header with bearer token (OAuth, JWT, etc.)
-- **API Key**: Custom header with API key
+### Basic Authentication
 
-### Authentication Types
-
-#### Basic Authentication
-
-**Environment Variables (Recommended):**
 ```bash
-# Using default environment variables
+# Environment variables (recommended)
 export LT_AUTH_TYPE=basic
-export LT_AUTH_BASIC_USERNAME="myuser" 
+export LT_AUTH_BASIC_USERNAME="myuser"
 export LT_AUTH_BASIC_PASSWORD="mypass"
 ./linktadoru https://protected.example.com
 
-# Alternative: use CLI flags to specify custom env vars
-export MY_USER="myuser"
-export MY_PASS="mypass"
-./linktadoru --auth-type basic --auth-username=$MY_USER --auth-password=$MY_PASS https://protected.example.com
-```
-
-**CLI Flags (Not Recommended for Production):**
-```bash
+# CLI flags (not recommended: visible in process lists and shell history)
 ./linktadoru --auth-type basic --auth-username myuser --auth-password mypass https://protected.example.com
 ```
 
-**Configuration File (Not Recommended):**
-```yaml
-# linktadoru.yml - NOT recommended for security reasons
-auth:
-  type: basic
-  basic:
-    username: "myuser"
-    password: "mypass"
-```
+### Bearer Token Authentication
 
-#### Bearer Token Authentication
-
-**Environment Variables (Recommended):**
 ```bash
+# Environment variables (recommended)
 export LT_AUTH_TYPE=bearer
-export LT_AUTH_BEARER_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+export LT_AUTH_BEARER_TOKEN="your-jwt-token"
 ./linktadoru https://api.example.com
-```
 
-**CLI Flags:**
-```bash
+# CLI flags
 ./linktadoru --auth-type bearer --auth-token "your-bearer-token" https://api.example.com
 ```
 
-#### API Key Authentication
+### API Key Authentication
 
-**Environment Variables (Recommended):**
 ```bash
+# Environment variables (recommended)
 export LT_AUTH_TYPE=api-key
 export LT_AUTH_APIKEY_HEADER="X-API-Key"
 export LT_AUTH_APIKEY_VALUE="your-api-key-here"
 ./linktadoru https://api.example.com
+
+# CLI flags
+./linktadoru --auth-type api-key --auth-header "X-API-Key" --auth-value "your-api-key" https://api.example.com
 ```
 
-**CLI Flags:**
-```bash
-./linktadoru --auth-type api-key --auth-header "X-API-Key" --auth-value "your-api-key" https://api.example.com
+### Configuration File
+
+Credentials can also be set in `linktadoru.yml` (not recommended for files committed to version control). Each auth block additionally supports `*_env` keys naming a custom environment variable to read the value from — see [linktadoru.yml.example](../linktadoru.yml.example).
+
+```yaml
+auth:
+  type: "bearer"
+  bearer:
+    token: "your-token-here"
 ```
 
 ### Security Best Practices
@@ -253,9 +209,8 @@ headers:
 
 The following headers cannot be overridden for security and protocol compliance:
 - `Host`
-- `Content-Length`  
+- `Content-Length`
 - `Connection`
-- `Transfer-Encoding`
 
 ### Combined Authentication and Headers Example
 
@@ -275,9 +230,9 @@ Only URLs matching at least one include pattern will be crawled:
 
 ```yaml
 include_patterns:
-  - "^https?://[^/]*httpbin\.org/.*"     # Main domain
-  - "^https?://[^/]*\.httpbin\.org/.*"   # All subdomains
-  - ".*/products/.*"                     # Specific path
+  - "^https?://[^/]*httpbin\\.org/.*"     # Main domain
+  - "^https?://[^/]*\\.httpbin\\.org/.*"  # All subdomains
+  - ".*/products/.*"                      # Specific path
 ```
 
 ### Exclude Patterns
@@ -285,37 +240,43 @@ URLs matching any exclude pattern will be skipped:
 
 ```yaml
 exclude_patterns:
-  - "\.pdf$"          # Skip PDFs
-  - "\.jpg$"          # Skip images
+  - "\\.pdf$"         # Skip PDFs
+  - "\\.jpg$"         # Skip images
   - "/admin/.*"       # Skip admin section
-  - ".*\?.*"          # Skip URLs with query strings
-  - ".*#.*"           # Skip URLs with fragments
+  - ".*\\?.*"         # Skip URLs with query strings
 ```
 
+Invalid regexes are rejected at startup with a clear error message.
+
 ## Performance Tuning
+
+`request_delay` is a number of seconds (e.g. `0.5`), not a duration string.
 
 ### Small Sites (< 1,000 pages)
 ```yaml
 concurrency: 5
-request_delay: 1s
+request_delay: 1
 ```
 
 ### Medium Sites (1,000 - 50,000 pages)
 ```yaml
-concurrency: 10-20
-request_delay: 500ms-1s
+concurrency: 10
+request_delay: 0.5
 ```
 
 ### Large Sites (> 50,000 pages)
+
+Start around these values and adjust; 20–50 workers with a 0.2–0.5s delay is a reasonable range if the target site tolerates it:
+
 ```yaml
-concurrency: 20-50
-request_delay: 200ms-500ms
+concurrency: 20
+request_delay: 0.2
 ```
 
 ### Respectful Crawling
 ```yaml
 concurrency: 2
-request_delay: 5s
+request_delay: 5
 ignore_robots_txt: false
-user_agent: "PoliteBot/1.0 (https://httpbin.org/bot)"
+user_agent: "PoliteBot/1.0 (https://example.com/bot)"
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,16 +12,18 @@
 
 ```
 .
-├── cmd/crawler/          # Main application entry point
+├── cmd/crawler/           # Main application entry point
 ├── internal/
-│   ├── cmd/             # CLI command handling
-│   ├── config/          # Configuration management
-│   ├── crawler/         # Core crawling logic
-│   ├── parser/          # HTML parsing
-│   └── storage/         # Database operations
-├── docs/                # Documentation
-├── .github/workflows/   # GitHub Actions CI/CD
-└── config.yaml.example  # Example configuration
+│   ├── cmd/               # CLI command handling
+│   ├── config/            # Configuration management
+│   ├── crawler/           # Core crawling logic
+│   ├── logging/           # Logging setup and rotation
+│   ├── parser/            # HTML parsing
+│   └── storage/           # Database operations
+├── docs/                  # Documentation
+├── scripts/               # Helper scripts
+├── .github/workflows/     # GitHub Actions CI/CD
+└── linktadoru.yml.example # Example configuration
 ```
 
 ## Building
@@ -155,9 +157,6 @@ docker run --rm -v $(pwd):/workspace linktadoru-dev make check
 
 # Interactive shell
 docker run -it --rm -v $(pwd):/workspace linktadoru-dev bash
-
-# Local GitHub Actions testing
-docker run --rm -v $(pwd):/workspace -v /var/run/docker.sock:/var/run/docker.sock linktadoru-dev act
 ```
 
 ## Development Workflow
@@ -178,7 +177,6 @@ Follow the coding standards:
 
 ### 3. Run Checks
 
-#### Traditional Testing
 ```bash
 # Run all checks
 make check
@@ -189,21 +187,7 @@ make lint
 make test
 ```
 
-#### Local CI Testing (Advanced)
-```bash
-# Install act (if not already installed)
-brew install act  # macOS
-# or follow docs/github-actions-local-testing.md
-
-# Run CI locally with act
-make act
-
-# Test specific job
-make act-test
-
-# List available workflows
-make act-list
-```
+Optionally, run the CI workflow locally with act (`make act`) — see [github-actions-local-testing.md](github-actions-local-testing.md).
 
 ### 4. Commit Changes
 
@@ -230,14 +214,7 @@ git push origin feature/your-feature
 gh pr create --title "feat: your feature" --body "Description of changes"
 ```
 
-**CI Strategy**: 
-- ✅ **PR → main**: CI runs automatically
-- ❌ **push → main**: CI does not run automatically  
-- 🔧 **Manual trigger**: `gh workflow run CI --ref main`
-
-See [github-actions-local-testing.md](github-actions-local-testing.md) for details.
-
-Create a pull request on GitHub. CI will run automatically.
+Create a pull request on GitHub. CI runs automatically on PRs to `main` — see [.github/workflows/README.md](../.github/workflows/README.md) for the exact trigger conditions.
 
 ## Database Management
 
@@ -280,24 +257,7 @@ go tool pprof -http=:8080 profile.out
 
 ## Release Process
 
-### 1. Update Version
-
-Update version in relevant files if needed.
-
-### 2. Create Tag
-
-```bash
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-### 3. GitHub Actions
-
-The release workflow automatically:
-- Runs tests
-- Builds binaries for all platforms
-- Creates GitHub release
-- Uploads artifacts
+Releases are tag-driven: pushing a `v*` tag triggers the release workflow. See [versioning-and-releases.md](versioning-and-releases.md) for the full process, artifact naming, and version embedding.
 
 ## Troubleshooting
 
@@ -310,10 +270,15 @@ The release workflow automatically:
 
 ### Debug Mode
 
-Enable debug logging:
+Enable debug logging via the configuration file (logging options have no CLI flags or environment variables):
+
+```yaml
+# linktadoru.yml
+log_level: "debug"
+```
 
 ```bash
-LOG_LEVEL=debug ./linktadoru https://httpbin.org
+./linktadoru --config linktadoru.yml https://httpbin.org
 ```
 
 ## Contributing

--- a/docs/github-actions-local-testing.md
+++ b/docs/github-actions-local-testing.md
@@ -36,30 +36,28 @@ git add .
 git commit -m "Initial commit"
 ```
 
-### Project Configuration (.actrc)
+### Basic Usage
 
-The `.actrc` file is configured in the project root:
+The Makefile provides shortcuts:
 
 ```bash
-# Use Ubuntu 22.04 image (better compatibility)
--P ubuntu-latest=catthehacker/ubuntu:act-22.04
+# Run the CI workflow locally
+make act
 
-# Environment variables
---env GO_VERSION=1.23
+# List available workflows/jobs
+make act-list
 
-# Don't use gitignore
---use-gitignore=false
-
-# Verbose output
---verbose
+# Run only the test job
+make act-test
 ```
 
-### Basic Usage
+Or invoke act directly:
+
 ```bash
 # List workflows
 act --list
 
-# Recommended: Run CI workflow (.actrc applied automatically)
+# Run CI workflow
 act -W .github/workflows/ci.yml
 
 # Run specific job only
@@ -70,6 +68,16 @@ act -W .github/workflows/ci.yml --dryrun
 
 # Simulate PR event
 act pull_request -W .github/workflows/ci.yml
+```
+
+Useful flags (can be persisted in a local `.actrc` file if you create one):
+
+```bash
+# Use Ubuntu 22.04 image (better compatibility)
+act -P ubuntu-latest=catthehacker/ubuntu:act-22.04
+
+# Set environment variables
+act --env GO_VERSION=1.23
 ```
 
 ### Environment Variables
@@ -98,7 +106,7 @@ act --secret-file .secrets
 
 ## 4. Manual CI Execution (workflow_dispatch)
 
-CI strategy has changed - CI no longer runs on direct pushes to main branch. Manual execution is available when needed.
+CI does not run on direct pushes to the main branch (see [.github/workflows/README.md](../.github/workflows/README.md)). Manual execution is available when needed.
 
 ### Using GitHub CLI
 ```bash
@@ -119,8 +127,6 @@ gh run list --workflow=CI --limit 5
 4. Select branch and click **Run workflow**
 
 ## 5. Recommended Workflow
-
-Current CI strategy (inspired by act project):
 
 1. **Local Testing**: Use act for basic functionality checks
 2. **Pull Requests**: Automatic CI execution on PRs to main branch

--- a/docs/technical-specification.ja.md
+++ b/docs/technical-specification.ja.md
@@ -135,6 +135,15 @@ RETURNING id, url
 - **状態追跡**: 明確な遷移: `discovered` → `pending` → `processing` → `completed`/`skipped`/`error`
 - **再開可能性**: 永続的な状態でプロセス中断を生き延びる
 
+#### リトライ処理
+
+リトライはHTTPクライアントではなく、クロールループとストレージレイヤーが担います：
+
+- キューが空になった後、`last_error_type = 'network_error'`（一時的なトランスポート障害）で失敗したページのみが再キューされ、1回の実行につき1リトライパスが行われる
+- 試行回数は`retry_count`カラムで追跡され、実行をまたいでURLごとに合計3回まで
+- 試行間のバックオフはなく、通常のドメイン別レート制限が適用される
+- 決定的な失敗（不正なURLなど）は意図的にリトライしない
+
 ### 3. HTTPクライアント
 
 **パッケージ**: `internal/crawler/http_client.go`
@@ -142,10 +151,11 @@ RETURNING id, url
 機能：
 - カスタムUser-Agentサポート
 - 設定可能なタイムアウト
-- 指数バックオフによる自動リトライ
 - コネクションプーリング
 - レスポンスサイズ制限
 - パフォーマンスメトリクスの収集（TTFB、ダウンロード時間）
+
+HTTPクライアント自体はリクエストごとに1回だけフェッチを行います。リトライはクロールレベルで処理されます（上記「リトライ処理」参照）。
 
 ### 4. HTMLパーサー
 
@@ -174,123 +184,14 @@ SQLiteベースのストレージ：
 
 #### データベーススキーマ
 
-**統合Pagesテーブル（キュー＋結果）:**
+正式なスキーマ定義は [`internal/storage/schema.go`](../internal/storage/schema.go) にあり、初回実行時に自動的に作成されます。SQLをここに複製する代わりに、その背後にある設計判断を示します：
 
-```sql
--- Pagesテーブルはキューと結果ストレージを兼用
-CREATE TABLE pages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    url TEXT UNIQUE NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error', 'discovered')),
-    
-    -- キュー関連フィールド
-    added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    processing_started_at DATETIME,
-    
-    -- クロール結果フィールド（クロール完了まではNULL）
-    status_code INTEGER,
-    title TEXT,
-    meta_description TEXT,
-    meta_robots TEXT,
-    canonical_url TEXT,
-    content_hash TEXT,
-    ttfb_ms INTEGER,
-    download_time_ms INTEGER,
-    response_size_bytes INTEGER,
-    content_type TEXT,
-    content_length INTEGER,
-    last_modified DATETIME,
-    server TEXT,
-    content_encoding TEXT,
-    crawled_at DATETIME,
-    
-    -- エラー追跡
-    retry_count INTEGER DEFAULT 0,
-    last_error_type TEXT,
-    last_error_message TEXT
-);
-```
-
-**サポートテーブル:**
-
-```sql
--- リンク関係テーブル（ページIDによる正規化）
--- 注意: UNIQUE制約により重複関係を防止。同じリンクが異なるanchor_textで
--- 複数回見つかった場合、最初の出現のみが保存されます。
-CREATE TABLE link_relations (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source_page_id INTEGER NOT NULL,
-    target_page_id INTEGER NOT NULL,
-    anchor_text TEXT,
-    link_type TEXT,
-    rel_attribute TEXT,
-    crawled_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (source_page_id) REFERENCES pages(id),
-    FOREIGN KEY (target_page_id) REFERENCES pages(id),
-    UNIQUE(source_page_id, target_page_id)
-);
-
--- ユーザー向けリンクビュー（URLベースのインターフェース維持）
-CREATE VIEW links AS
-SELECT 
-    lr.id,
-    p1.url AS source_url,
-    p2.url AS target_url,
-    lr.anchor_text,
-    lr.link_type,
-    lr.rel_attribute,
-    lr.crawled_at
-FROM link_relations lr
-JOIN pages p1 ON lr.source_page_id = p1.id
-JOIN pages p2 ON lr.target_page_id = p2.id;
-
--- 詳細エラー追跡用の別テーブル
-CREATE TABLE crawl_errors (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    url TEXT NOT NULL,
-    error_type TEXT NOT NULL,
-    error_message TEXT,
-    occurred_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
--- メタデータテーブル
-CREATE TABLE crawl_meta (
-    key TEXT PRIMARY KEY NOT NULL,
-    value TEXT NOT NULL
-);
-```
-
-**最適化インデックス:**
-
-```sql
--- キュー操作用の重要インデックス
-CREATE INDEX idx_pages_status ON pages(status);
-CREATE INDEX idx_pages_status_added ON pages(status, added_at);
-CREATE INDEX idx_pages_url ON pages(url);
-
--- 完了したデータのみの条件付きインデックス
-CREATE INDEX idx_pages_content_hash ON pages(content_hash) WHERE content_hash IS NOT NULL;
-CREATE INDEX idx_pages_status_code ON pages(status_code) WHERE status = 'completed';
-```
-
-**分析ビュー:**
-
-```sql
--- 完了ページのみのビュー（分析・レポート用）
-CREATE VIEW completed_pages AS
-SELECT id, url, status_code, title, meta_description, meta_robots,
-       canonical_url, content_hash, ttfb_ms, download_time_ms,
-       response_size_bytes, content_type, content_length,
-       last_modified, server, content_encoding, crawled_at
-FROM pages WHERE status = 'completed';
-
--- キュー管理ビュー
-CREATE VIEW queue_status AS
-SELECT status, COUNT(*) as count,
-       MIN(added_at) as oldest_item,
-       MAX(added_at) as newest_item
-FROM pages GROUP BY status;
-```
+- **統合`pages`テーブル**: URLごとに1行がキューエントリとクロール結果を兼ねる。`status`カラムが上述のライフサイクルを駆動し、クロール結果カラムは取得完了まで`NULL`のまま。
+- **HTTPヘッダーのJSON格納と生成カラム**: レスポンスヘッダー全体を`response_http_headers`（JSON）に一度だけ保存。頻繁に照会されるヘッダー — `content_type`、`content_length`、`last_modified`、`server`、`content_encoding`、`x_cache` — は`GENERATED ALWAYS ... STORED`カラムとして公開され、書き込みロジックを複製せずに通常のカラム同様にインデックス・照会できる。
+- **正規化されたリンクグラフ**: `link_relations`はエッジをページIDのペアとして保存し、`UNIQUE(source_page_id, target_page_id)`制約を持つ（同じリンクが異なるアンカーテキストで複数回見つかった場合、最初のもののみ保持）。`links`ビューがエッジをURLペアとして再公開し、分析を容易にする。
+- **分析ビュー**: `completed_pages`（取得済みページのみ）と`queue_status`（ステータス別件数と最古/最新タイムスタンプ）が統合テーブルへの安定した照会インターフェースを提供。
+- **サポートテーブル**: `crawl_errors`は診断用にすべてのエラー発生を記録し、`crawl_meta`はキー・バリュー形式のクロールメタデータを保存。
+- **インデックス戦略**: キュー操作は`status`および`(status, added_at)`のインデックスで支え、分析用カラムには部分インデックス（例: `WHERE content_hash IS NOT NULL`）を用いてキューへの書き込みを軽量に保つ。
 
 ### 6. レートリミッター
 
@@ -301,3 +202,5 @@ FROM pages GROUP BY status;
 - トークンバケットアルゴリズム
 - 設定可能な遅延
 - ノンブロッキング設計
+
+robots.txtの`Crawl-delay`ディレクティブは、設定されたリクエスト遅延より遅い場合に適用され、上限は60秒です。

--- a/docs/technical-specification.md
+++ b/docs/technical-specification.md
@@ -135,6 +135,15 @@ RETURNING id, url
 - **State Tracking**: Clear transitions: `discovered` → `pending` → `processing` → `completed`/`skipped`/`error`
 - **Resumability**: Persistent state survives process interruptions
 
+#### Retry Handling
+
+Retries are driven by the crawl loop and the storage layer, not by the HTTP client:
+
+- After the queue drains, pages that failed with `last_error_type = 'network_error'` (transient transport failures) are requeued for one retry pass per run
+- Attempts are bounded to 3 in total per URL across runs, tracked in the `retry_count` column
+- There is no backoff between attempts; the normal per-domain rate limiting applies
+- Deterministic failures (e.g. malformed URLs) are deliberately not retried
+
 ### 3. HTTP Client
 
 **Package**: `internal/crawler/http_client.go`
@@ -142,10 +151,11 @@ RETURNING id, url
 Features:
 - Custom User-Agent support
 - Configurable timeouts
-- Automatic retry with exponential backoff
 - Connection pooling
 - Response size limits
 - Performance metric collection (TTFB, download time)
+
+The HTTP client performs a single fetch per request; retries are handled at the crawl level (see Retry Handling above).
 
 ### 4. HTML Parser
 
@@ -174,123 +184,14 @@ SQLite-based storage with:
 
 #### Database Schema
 
-**Unified Pages Table (Queue + Results):**
+The authoritative schema is defined in [`internal/storage/schema.go`](../internal/storage/schema.go) and is created automatically on first run. Rather than duplicating the SQL here, these are the design decisions behind it:
 
-```sql
--- Pages table serves as both queue and results storage
-CREATE TABLE pages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    url TEXT UNIQUE NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'skipped', 'error', 'discovered')),
-    
-    -- Queue-related fields
-    added_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    processing_started_at DATETIME,
-    
-    -- Crawl result fields (NULL until crawled)
-    status_code INTEGER,
-    title TEXT,
-    meta_description TEXT,
-    meta_robots TEXT,
-    canonical_url TEXT,
-    content_hash TEXT,
-    ttfb_ms INTEGER,
-    download_time_ms INTEGER,
-    response_size_bytes INTEGER,
-    content_type TEXT,
-    content_length INTEGER,
-    last_modified DATETIME,
-    server TEXT,
-    content_encoding TEXT,
-    crawled_at DATETIME,
-    
-    -- Error tracking
-    retry_count INTEGER DEFAULT 0,
-    last_error_type TEXT,
-    last_error_message TEXT
-);
-```
-
-**Supporting Tables:**
-
-```sql
--- Link relationships table (normalized with page IDs)
--- NOTE: UNIQUE constraint prevents duplicate relationships. If the same link
--- is found multiple times with different anchor_text, only the first is stored.
-CREATE TABLE link_relations (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source_page_id INTEGER NOT NULL,
-    target_page_id INTEGER NOT NULL,
-    anchor_text TEXT,
-    link_type TEXT,
-    rel_attribute TEXT,
-    crawled_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (source_page_id) REFERENCES pages(id),
-    FOREIGN KEY (target_page_id) REFERENCES pages(id),
-    UNIQUE(source_page_id, target_page_id)
-);
-
--- User-friendly links view (maintains URL-based interface)
-CREATE VIEW links AS
-SELECT 
-    lr.id,
-    p1.url AS source_url,
-    p2.url AS target_url,
-    lr.anchor_text,
-    lr.link_type,
-    lr.rel_attribute,
-    lr.crawled_at
-FROM link_relations lr
-JOIN pages p1 ON lr.source_page_id = p1.id
-JOIN pages p2 ON lr.target_page_id = p2.id;
-
--- Separate errors table for detailed error tracking
-CREATE TABLE crawl_errors (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    url TEXT NOT NULL,
-    error_type TEXT NOT NULL,
-    error_message TEXT,
-    occurred_at DATETIME DEFAULT CURRENT_TIMESTAMP
-);
-
--- Metadata table
-CREATE TABLE crawl_meta (
-    key TEXT PRIMARY KEY NOT NULL,
-    value TEXT NOT NULL
-);
-```
-
-**Optimized Indexes:**
-
-```sql
--- Critical indexes for queue operations
-CREATE INDEX idx_pages_status ON pages(status);
-CREATE INDEX idx_pages_status_added ON pages(status, added_at);
-CREATE INDEX idx_pages_url ON pages(url);
-
--- Conditional indexes for completed data only
-CREATE INDEX idx_pages_content_hash ON pages(content_hash) WHERE content_hash IS NOT NULL;
-CREATE INDEX idx_pages_status_code ON pages(status_code) WHERE status = 'completed';
-```
-
-**Analysis Views:**
-
-```sql
--- View for completed pages only (for analysis/reporting)
-CREATE VIEW completed_pages AS
-SELECT id, url, status_code, title, meta_description, meta_robots,
-       canonical_url, content_hash, ttfb_ms, download_time_ms,
-       response_size_bytes, content_type, content_length,
-       last_modified, server, content_encoding, crawled_at
-FROM pages WHERE status = 'completed';
-
--- View for queue management
-CREATE VIEW queue_status AS
-SELECT status, COUNT(*) as count,
-       MIN(added_at) as oldest_item,
-       MAX(added_at) as newest_item
-FROM pages GROUP BY status;
-```
+- **Unified `pages` table**: one row per URL serves as both queue entry and crawl result. The `status` column drives the lifecycle described above; crawl-result columns stay `NULL` until the page is fetched.
+- **HTTP headers as JSON with generated columns**: the full response headers are stored once in `response_http_headers` (JSON). Frequently queried headers — `content_type`, `content_length`, `last_modified`, `server`, `content_encoding`, `x_cache` — are exposed as `GENERATED ALWAYS ... STORED` columns, so they can be indexed and queried like ordinary columns without duplicating write logic.
+- **Normalized link graph**: `link_relations` stores edges as page-ID pairs with a `UNIQUE(source_page_id, target_page_id)` constraint (if the same link is found multiple times with different anchor text, only the first is kept). The `links` view re-exposes edges as URL pairs for convenient analysis.
+- **Analysis views**: `completed_pages` (fetched pages only) and `queue_status` (per-status counts with oldest/newest timestamps) provide stable query interfaces over the unified table.
+- **Supporting tables**: `crawl_errors` records every error occurrence for diagnostics; `crawl_meta` stores key-value crawl metadata.
+- **Index strategy**: queue operations are backed by indexes on `status` and `(status, added_at)`; analysis columns use partial indexes (e.g. `WHERE content_hash IS NOT NULL`) so queue writes stay cheap.
 
 ### 6. Rate Limiter
 
@@ -301,3 +202,5 @@ Implementation:
 - Token bucket algorithm
 - Configurable delays
 - Non-blocking design
+
+robots.txt `Crawl-delay` directives are honored when they are slower than the configured request delay, capped at 60 seconds.

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -21,9 +21,9 @@ This project follows [Semantic Versioning](https://semver.org/):
 ### 2.1 Regular Release
 
 ```bash
-# 1. After development is complete, merge develop to main
+# 1. Make sure main is green (all PRs merged, CI passing)
 git checkout main
-git merge develop
+git pull
 
 # 2. Create version tag
 git tag v1.0.0
@@ -34,12 +34,10 @@ git push origin v1.0.0
 
 ### 2.2 Pre-release (Beta)
 
-```bash
-# 1. Create beta tag on develop branch
-git checkout develop
-git tag v1.1.0-beta.1
+Pre-release tags trigger the same release workflow:
 
-# 2. Push tag
+```bash
+git tag v1.1.0-beta.1
 git push origin v1.1.0-beta.1
 ```
 
@@ -47,46 +45,24 @@ git push origin v1.1.0-beta.1
 
 ### 3.1 File Naming Convention
 
-```
-linktadoru-[VERSION]-[OS]-[ARCH][SUFFIX]
-```
+Release binaries are named without a version suffix (the version is embedded in the binary and shown by `--version`):
 
-**Examples:**
-- `linktadoru-v1.0.0-linux-amd64`
-- `linktadoru-v1.0.0-darwin-arm64`
-- `linktadoru-v1.0.0-windows-amd64.exe`
+```
+linktadoru-[OS]-[ARCH][.exe]
+```
 
 ### 3.2 Supported Platforms
 
-| OS | Architecture | Example Filename |
-|----|--------------|------------------|
-| Linux | AMD64 | `linktadoru-v1.0.0-linux-amd64` |
-| macOS | ARM64 | `linktadoru-v1.0.0-darwin-arm64` |
-| Windows | AMD64 | `linktadoru-v1.0.0-windows-amd64.exe` |
-
-### 3.3 Checksums
-
-Each binary comes with a `.sha256` file:
-```bash
-# Verification example
-sha256sum -c linktadoru-v1.0.0-linux-amd64.sha256
-```
+| OS | Architecture | Filename |
+|----|--------------|----------|
+| Linux | AMD64 | `linktadoru-linux-amd64` |
+| Linux | ARM64 | `linktadoru-linux-arm64` |
+| macOS | ARM64 | `linktadoru-darwin-arm64` |
+| Windows | AMD64 | `linktadoru-windows-amd64.exe` |
 
 ## 4. CI/CD Trigger Conditions
 
-### 4.1 CI (Test & Build)
-
-**Triggered on:**
-- Push to `main` or `develop` branches
-- Pull requests to `main` branch
-
-**Skipped on:**
-- Documentation-only changes (`*.md`, `docs/**`, `LICENSE`, `.gitignore`)
-
-### 4.2 Release
-
-**Triggered on:**
-- Tag push with `v*` pattern (e.g., `v1.0.0`, `v1.2.3-beta.1`)
+See [.github/workflows/README.md](../.github/workflows/README.md) for the authoritative description of the workflows. In short: CI runs on pull requests to `main` (documentation-only changes are skipped) and on manual dispatch; the release workflow runs on `v*` tag pushes.
 
 ## 5. Version Information Embedding
 
@@ -109,29 +85,26 @@ var (
 ## 6. Branch Strategy
 
 ```
-main (production)
+main (stable, release tags)
  ↑
-develop (development)
- ↑
-feature/* (feature branches)
+feature/* (feature branches, merged via PR)
 ```
 
-### Branch Behavior
-
-| Branch | CI Run | Release | Description |
-|--------|--------|---------|-------------|
-| `main` | ✅ | Tags only | Stable version |
-| `develop` | ✅ | - | Development version |
-| `feature/*` | PR only | - | Feature development |
+| Branch | CI Run | Release |
+|--------|--------|---------|
+| `main` | Manual dispatch only | Tags only |
+| `feature/*` | On PR to `main` | - |
 
 ## 7. Manual Local Build
+
+The Makefile derives `VERSION` from `git describe`; override it on the make command line (an environment variable will not override it):
 
 ```bash
 # Development build
 make build
 
-# Release build (with version)
-VERSION=1.0.0 BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ) make build
+# Release build (with explicit version)
+make build VERSION=1.0.0 BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Cross-compile
 GOOS=darwin GOARCH=arm64 make build
@@ -146,18 +119,12 @@ For critical bug fixes:
 git checkout main
 git checkout -b hotfix/v1.0.1
 
-# 2. Commit fixes
+# 2. Commit fixes and open a PR to main
 git commit -m "Fix critical bug"
 
-# 3. Merge to main
+# 3. After the PR is merged, tag the patch release
 git checkout main
-git merge hotfix/v1.0.1
-
-# 4. Release patch version
+git pull
 git tag v1.0.1
 git push origin v1.0.1
-
-# 5. Merge to develop as well
-git checkout develop
-git merge main
 ```

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -30,31 +30,33 @@ exclude_patterns:           # Regex patterns for URLs to exclude
   - "\\.exe$"              # Exclude executable files
 
 # Authentication configuration
-# Note: You can use only one authentication method at a time
+# Note: configure AT MOST ONE method — filling in credentials for more than one
+# fails validation ("multiple authentication types configured simultaneously").
+# Uncomment only the block you use.
 auth:
   type: ""                  # Authentication type: "", "basic", "bearer", or "api-key"
-  
+
   # Basic Authentication
-  basic:
-    username: "user"        # Basic auth username
-    password: "pass"        # Basic auth password
-    # Alternative: use environment variables
-    # username_env: "LT_AUTH_BASIC_USERNAME"
-    # password_env: "LT_AUTH_BASIC_PASSWORD"
-  
+  # basic:
+  #   username: "user"        # Basic auth username
+  #   password: "pass"        # Basic auth password
+  #   # Alternative: use environment variables
+  #   # username_env: "LT_AUTH_BASIC_USERNAME"
+  #   # password_env: "LT_AUTH_BASIC_PASSWORD"
+
   # Bearer Token Authentication
-  bearer:
-    token: "your_token_here"  # Bearer token
-    # Alternative: use environment variable
-    # token_env: "LT_AUTH_BEARER_TOKEN"
-  
+  # bearer:
+  #   token: "your_token_here"  # Bearer token
+  #   # Alternative: use environment variable
+  #   # token_env: "LT_AUTH_BEARER_TOKEN"
+
   # API Key Authentication
-  apikey:
-    header: "X-API-Key"     # Header name for API key
-    value: "your_key_here"  # API key value
-    # Alternative: use environment variables
-    # header_env: "LT_AUTH_API_KEY_HEADER"
-    # value_env: "LT_AUTH_API_KEY_VALUE"
+  # apikey:
+  #   header: "X-API-Key"     # Header name for API key
+  #   value: "your_key_here"  # API key value
+  #   # Alternative: use environment variables
+  #   # header_env: "LT_AUTH_APIKEY_HEADER"
+  #   # value_env: "LT_AUTH_APIKEY_VALUE"
 
 # Custom HTTP headers
 headers:


### PR DESCRIPTION
## Summary

Documentation-only overhaul following a full docs audit (two independent review agents; every factual claim verified against the code, several empirically with the real binary). **19 files, net −480 lines. No code changes.**

## Fixed (wrong / copy-paste-breaking)

- `--delay 2s`, `request_delay: 1s` and similar duration-string examples failed to parse (the fields are numeric seconds) — all examples are numeric now
- "Every option can be set via `LT_` environment variables" was false — corrected to flag-bound keys only; `log_*` / `allowed_schemes` documented as config-file only; invalid `LOG_LEVEL=debug` example removed
- Technical spec claimed the HTTP client does "automatic retries with exponential backoff" — replaced with the real mechanism (post-crawl requeue of `network_error` pages, one pass per run, 3 attempts total, no backoff)
- The schema SQL dump in the technical spec had drifted from `schema.go` again — replaced with a pointer to the code plus design rationale (JSON headers + generated columns, views), removing the recurring drift magnet
- CI/release facts synced to reality: PR→main triggers only (no `develop` branch exists), artifact names without version suffix incl. `linux-arm64`, no `.sha256` files, `make build VERSION=x` syntax
- Forbidden-header list, `config.yaml`/`examples/`/`.actrc` leftovers, SECURITY.md reporting-channel contradiction, stale env-var name examples
- `linktadoru.yml.example` failed validation as-is (placeholder credentials for all three auth methods → "multiple authentication types configured"); auth blocks are now commented out and the file is verified to parse and validate with the real binary

## Added

- **How Crawling Behaves** (basic-usage en/ja): page status lifecycle (`discovered`/`skipped`, "404 is `completed` — check `status_code`"), retry semantics, robots.txt `Crawl-delay` handling (slow-down only, 60s cap), Ctrl-C safe stop & resume
- configuration.md: Logging section, `allowed_schemes` / `log_*` table rows, `follow_external_hosts` and `max_response_size` wherever flags are listed
- Complete docs index (docs/README en/ja)

## Deduplicated (single source of truth)

configuration.md owns config/auth/headers/perf-tuning; README keeps a quickstart + links; CONTRIBUTING owns process and links development.md for setup; workflows/README owns CI triggers; github-actions-local-testing.md owns act usage. All changes mirrored across en/ja pairs; 57 relative links and cross-file anchors verified.

## Verification

- Independent verification agent: all 25 audit findings RESOLVED, no regressions, GO verdict
- New `linktadoru.yml.example` proven to parse (`--show-config`) and pass validation with the real binary
- Leftover-pattern grep sweep and full link check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
