### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-06
+
+### Added
+- `--seed-file` accepts seed URLs from a file, or from standard input with `-`.
+  Blank lines and `#` comments are ignored. Either explicit CLI form replaces
+  configured `seed_urls`; file and positional input are intentionally mutually
+  exclusive.
+- `max_depth` / `--max-depth` bounds a crawl by link distance from the supplied
+  seeds. Seeds are depth 0, depth N is included, and 0 remains unlimited. Links
+  beyond the bound stay in the link graph without being fetched.
+- The final crawl summary distinguishes completed, unavailable, unreachable,
+  skipped, unfinished, and graph-only discovered pages.
+
+### Changed
+- `max_depth=1` now schedules ready depth-1 pages without waiting for every
+  in-flight seed, so one slow landing page occupies only its own worker. Deeper
+  bounded crawls retain strict depth layers to keep shortest-path bounds correct.
+- HTTP 408, 429, 500, 502, 503, and 504 responses are retried up to the existing
+  three-attempt limit. `Retry-After` is honored with a 60-second cap, other
+  retries use deterministic backoff, and the observed status, headers, timing,
+  and size remain available for inspection. Exhausted transient responses stay
+  errors rather than being reported as successfully crawled pages. Retryable
+  work is drained within the run and recognized when resuming the same database.
+
 ## [0.9.2] - 2026-08-05
 
 ### Security


### PR DESCRIPTION
## What

Record the user-visible changes for v0.10.0:

- seed URLs from a file or standard input (#67);
- inclusive bounded crawling (#68);
- retries for transient HTTP responses with preserved observations (#71);
- non-blocking scheduling for `max_depth=1` (#72).

## Version choice

This is a minor release because it adds backward-compatible CLI and crawl configuration features after v0.9.2.

## Scope

This PR changes only `CHANGELOG.md`. The implementation PRs have already passed their Test, Lint, Security Scan, Build, race, and independent review gates. The release workflow will rerun tests and build all release binaries from the tag.

After merge, tag the resulting main commit as `v0.10.0`.
