### PR TITLE
Unify crawl URL authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - `--seed-file` reads generated seed lists from a file or standard input.
-- Positive `max_depth` values persist discovery depth and admit links through
-  that depth without a global breadth-first barrier. Bounded crawls temporarily
-  require explicit seeds and a fresh database; `max_depth: 0` remains unlimited.
+- SQLite now persists first-discovery depth. `max_depth: N` accepts any
+  non-negative N, prioritizes shallow queued work without a breadth-first
+  barrier, and supports depth-preserving resume.
+- URL authorization now uses one policy: exact persisted seed origins plus
+  full-URL include regexes, minus exclude regexes. Includes can explicitly add
+  cross-origin ranges; relative legacy includes fail with a migration message.
 
 ### Changed
 - Re-supplying an existing URL as a seed re-fetches it at depth 0 and clears
-  stale observations. Normal duplicate discovery still does not re-fetch it.
+  stale observations. Normal duplicate discovery still does not re-fetch a
+  queued or terminal URL.
+- Runs without explicit seeds now drain resumable database work, including
+  bounded crawls, or exit successfully when no work remains.
+- Seed URLs containing userinfo are rejected; configure credentials separately.
 - Crawling stops before network access when a migrated database has unfinished
   rows with unknown depth. Supply those URLs as seeds or use a fresh database.
+- Existing absolute non-seed-origin includes are now active cross-origin
+  authorization under OR semantics. Review these patterns before upgrading.
+- Credentials and configured custom headers are sent only to origins supplied
+  as seeds in the current invocation, and never reappear after an A-B-A
+  cross-origin redirect chain.
+- Outgoing external links are retained as graph-only `discovered` rows even
+  when their URLs are not authorized for fetching.
+- In multi-seed crawls, links between persisted seed origins can now be fetched;
+  the old parent-host `internal` link gate no longer narrows the shared policy.
 
 ### Fixed
 - HTTP 408, 429, 500, 502, 503, and 504 responses are now retained as errors

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ user_agent: "LinkTadoru/1.0"
 ignore_robots_txt: false
 database_path: "./linktadoru.db"
 limit: 0                     # 0 = unlimited
-max_depth: 0                 # 0 = unlimited; N > 0 includes discovery depth N
+max_depth: 0                 # 0 = unlimited; positive N includes discovery depth N
 
 # URL filtering
 include_patterns: []

--- a/docs/basic-usage.ja.md
+++ b/docs/basic-usage.ja.md
@@ -20,7 +20,7 @@
 ./linktadoru --limit 10 --concurrency 2 --delay 2 https://httpbin.org
 ```
 
-### 3. シード一覧と1ホップのクロール
+### 3. シード一覧と深さ制限付きクロール
 
 実行ごとに生成した対象はファイルから読みます。`-` は標準入力です。
 
@@ -32,10 +32,12 @@ fetch-target-list | ./linktadoru --seed-file - --max-depth 1 --limit 0
 シードファイルは1行1URLです。空行、前後の空白、`#`で始まるコメントは無視します。
 `--seed-file`とURL引数は同時に指定できません。
 
-`max_depth: 0`は無制限です。正の値では、シードをdepth 0、そのリンクをdepth 1
-として、指定した発見depthまでをキューへ入れます。キューは非同期のままなので、
-遅いページが別ワーカーで既に投入された深い処理を止めません。URLポリシーの復元が
-入るまで、bounded crawlには明示的なシードと新しい空のDBが必要です。
+`max_depth: N`は、深さ0のシードから深さNで登録された子までを取得します。0は
+無制限です。DBへ保存する値は最初に発見・登録された経路の深さであり、最短距離の
+保証ではありません。非同期キューは浅いURLを優先しますが、層全体の完了を待たない
+ため、遅いページ1件が他のワーカーを止めません。そのためNが2以上の場合、応答順に
+よって上限内に入る子孫が変わることがあります。独立して比較するスナップショットや、
+上限変更後に全URLを判定し直す場合は新しいDBを使ってください。
 
 一時的な応答（408、429、500、502、503、504）は観測内容をDBへ残し、通常処理の
 後に合計3回まで再試行します。
@@ -55,12 +57,12 @@ limit: 50
 database_path: "./mysite-crawl.db"
 
 include_patterns:
-  - "^https?://[^/]*httpbin\\.org/.*"
+  - '^https://search\.example/search(?:/.*)?(?:\?.*)?$'
 
 exclude_patterns:
-  - "\\.pdf$"
-  - "/admin/.*"
-  - ".*\\?print=1"
+  - '\.pdf$'
+  - '/admin/'
+  - '[?&]print=1(?:&|$)'
 ```
 
 設定ファイルを使用して実行：
@@ -68,6 +70,43 @@ exclude_patterns:
 ```bash
 ./linktadoru --config mysite-config.yml https://httpbin.org
 ```
+
+### URLパターンの規則
+
+通常は、DBに保存された深さ0のシードと同じorigin（scheme・hostname・実効port）を
+許可します。`include_patterns`は別の絶対URL範囲を追加し、`exclude_patterns`は
+許可集合からURLを除きます。excludeは常に優先されます。同じ判定を、キュー済みURL、
+発見リンク、redirect、retryに使います。
+
+正規表現はGo標準の`regexp`（RE2）です。
+
+- `/`は通常の文字なのでエスケープ不要です。JavaScriptの`/pattern/`記法ではありません。
+- `.`は任意の1文字です。hostnameのドットは`\.`と書きます。
+- includeは絶対URL文字列全体との一致です。読みやすさのため`^`と`$`を推奨します。
+- `/products/`のような相対includeは、意味を黙って変えず起動時にエラーにします。
+- excludeは部分一致を使えるため、`/ika/`やquery parameterの除外に向きます。
+- 正規表現は大文字と小文字を区別し、保存された絶対URL文字列をそのまま照合します。
+- URLをpercent-decodeしてから照合はしません。`/ika/`は`/%69ka/`に一致しません。
+- YAMLではsingle quoteを使うとbackslashをそのまま読みやすく書けます。
+
+```yaml
+seed_urls:
+  - https://example.com/
+
+include_patterns:
+  - '^https://hogehoge\.com/search(?:/.*)?(?:\?.*)?$'
+
+exclude_patterns:
+  - '/ika/'
+  - '[?&]page=[0-9]+(?:&|$)'
+```
+
+この例では`https://example.com/news/1`と
+`https://hogehoge.com/search/items?q=go`を許可し、
+`https://hogehoge.com/account`と`/ika/`を含むURLを拒否します。
+includeだけで許可されたoriginへは、認証情報や設定済みcustom headerを送りません。
+`^https?://.*$`のような広いincludeは、`follow_external_hosts: true`と同じ到達リスクを
+持ちます。
 
 ## 高度な使用例
 
@@ -105,16 +144,19 @@ LinkTadoruは既存のデータベースから自動的に再開します：
   https://httpbin.org
 ```
 
-### 4. パターンを使った集中クロール
+### 4. パターンで対象範囲を追加
 
-ブログ記事と記事のみをクロール：
+関連する検索endpointを追加し、静的assetを除外：
 
 ```bash
 ./linktadoru \
-  --include-patterns "^https?://[^/]*httpbin\.org/(blog|articles)/.*" \
+  --include-patterns "^https://search\.example/search(?:/.*)?(?:\?.*)?$" \
   --exclude-patterns "\\.jpg$|\\.png$|\\.css$|\\.js$" \
-  https://httpbin.org
+  https://example.com
 ```
+
+シードoriginは引き続き許可されます。includeは一致する`search.example`の範囲だけを
+追加し、excludeは両方の範囲から一致するassetを除外します。
 
 ## クロールの挙動
 
@@ -143,7 +185,7 @@ robots.txtの`Crawl-delay`は、設定した`request_delay`より遅い場合に
 
 ### 中断と再開
 
-Ctrl-C（SIGINT/SIGTERM）で安全に停止できます。処理中の状態は永続化され、データベースは正常にクローズされます。同じ`--database`を指定して再実行すれば再開でき、`processing`のまま残った行は次回起動時に自動的に再キューされます。ただし、bounded `max_depth`実行は一時的に明示的なシードと新しい空のDBを必要とします。
+Ctrl-C（SIGINT/SIGTERM）で安全に停止できます。処理中の状態は永続化され、データベースは正常にクローズされます。同じ`--database`を指定して再実行すれば再開でき、`processing`のまま残った行は次回起動時に深さを維持したまま再キューされます。URLをシードとして再指定すると、深さ0として再取得します。再利用したDBでは深さ0の起点が加算され、後から渡したシード一覧は以前の起点やキューを置き換えません。起点集合を置き換える場合や独立して比較できるスナップショットを作る場合は、新しいDBを使ってください。認証またはカスタムヘッダーを使う場合、資格情報を渡してよい起点をDB履歴から推測しないため、seedなしでは再開せず、シード一覧の再指定を要求します。このとき資格情報を送るのは今回指定したシードのoriginだけで、過去から蓄積された起点には送りません。
 
 ## 出力の分析
 

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -20,7 +20,7 @@ Crawl up to 10 pages with 2 concurrent workers and a 2-second delay (`--delay` t
 ./linktadoru --limit 10 --concurrency 2 --delay 2 https://httpbin.org
 ```
 
-### 3. Seed Lists and One-Hop Crawls
+### 3. Seed Lists and Depth-Limited Crawls
 
 Read generated targets from a file, or use `-` for standard input:
 
@@ -33,11 +33,13 @@ Seed files contain one URL per line. Blank lines, surrounding whitespace, and
 lines beginning with `#` are ignored. `--seed-file` cannot be combined with URL
 arguments.
 
-`max_depth: 0` is unlimited. A positive value admits links through that
-discovery depth: seeds are depth 0, their links are depth 1, and so on. The
-queue remains asynchronous, so one slow page does not block deeper work already
-admitted by another worker. Until URL-policy restoration lands, every bounded
-run requires explicit seeds and a fresh database.
+`max_depth: N` includes seeds at depth 0 through children admitted at depth N;
+0 is unlimited. The persisted value is first-discovery depth, not a guaranteed
+shortest path. The asynchronous queue prefers shallow work but does not wait for
+an entire layer, so one slow page does not block other workers. Consequently,
+for N >= 2, response timing can affect which descendants fit inside the bound.
+Use a fresh database for independently comparable snapshots or when changing
+the bound must reinterpret all work.
 
 Selected temporary responses (408, 429, 500, 502, 503, 504) are retained in the
 database and retried after normal queue work, up to three total attempts.
@@ -57,12 +59,12 @@ limit: 50
 database_path: "./mysite-crawl.db"
 
 include_patterns:
-  - "^https?://[^/]*httpbin\\.org/.*"
+  - '^https://search\.example/search(?:/.*)?(?:\?.*)?$'
 
 exclude_patterns:
-  - "\\.pdf$"
-  - "/admin/.*"
-  - ".*\\?print=1"
+  - '\.pdf$'
+  - '/admin/'
+  - '[?&]print=1(?:&|$)'
 ```
 
 Run with configuration:
@@ -70,6 +72,9 @@ Run with configuration:
 ```bash
 ./linktadoru --config mysite-config.yml https://httpbin.org
 ```
+
+See [Configuration](configuration.md#url-policy-and-regular-expressions) for
+the include/exclude authorization model and regular-expression examples.
 
 ## Advanced Examples
 
@@ -107,16 +112,19 @@ LinkTadoru automatically resumes from existing database:
   https://httpbin.org
 ```
 
-### 4. Focused Crawling with Patterns
+### 4. Extending Scope with Patterns
 
-Crawl only blog posts and articles:
+Add a related search endpoint and skip static assets:
 
 ```bash
 ./linktadoru \
-  --include-patterns "^https?://[^/]*httpbin\.org/(blog|articles)/.*" \
+  --include-patterns "^https://search\.example/search(?:/.*)?(?:\?.*)?$" \
   --exclude-patterns "\\.jpg$|\\.png$|\\.css$|\\.js$" \
-  https://httpbin.org
+  https://example.com
 ```
+
+The seed origin remains allowed. The include adds only the matching
+`search.example` range, and the exclude removes matching assets from both.
 
 ## How Crawling Behaves
 
@@ -145,7 +153,7 @@ A `Crawl-delay` in robots.txt is honored when it is slower than your configured 
 
 ### Interrupting and Resuming
 
-Ctrl-C (SIGINT/SIGTERM) stops the crawl gracefully: in-flight state is persisted and the database is closed cleanly. Rerun with the same `--database` to resume — rows left in `processing` are automatically requeued at the next start. Bounded `max_depth` runs temporarily require explicit seeds and a fresh, empty database.
+Ctrl-C (SIGINT/SIGTERM) stops the crawl gracefully: in-flight state is persisted and the database is closed cleanly. Rerun with the same `--database` to resume — rows left in `processing` are automatically requeued at the next start, and their discovery depth is preserved. Supplying a URL explicitly as a seed fetches it again at depth 0. Depth-0 roots accumulate in a reused database: a later seed list extends rather than replaces the earlier roots, and already queued work remains. Use a new database to replace the root set or create an independently comparable snapshot. A seedless resume cannot use authentication or custom headers because credential origins cannot be inferred safely; supply the seed list again. When seeds are supplied, credentials are sent only to origins in that invocation, not to older accumulated roots.
 
 ## Output Analysis
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,14 +20,14 @@ This table is the authoritative reference for all options. Run `./linktadoru --h
 | request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout (Go duration) |
 | user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
 | ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
-| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Allow crawling hosts other than the seed hosts |
+| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Compatibility switch allowing every URL with an allowed scheme; excludes still win |
 | limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
-| max_depth | `--max-depth` | `LT_MAX_DEPTH` | 0 | 0=unlimited; N>0 includes discovery depth N and temporarily requires explicit seeds plus an empty database |
+| max_depth | `--max-depth` | `LT_MAX_DEPTH` | 0 | Maximum first-discovery depth; 0=unlimited, seeds=0 |
 | max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes (10 MiB) |
 | database_path | `-d, --database` | `LT_DATABASE_PATH` | ./linktadoru.db | SQLite database file path |
 | **URL Filtering** |
-| include_patterns | `--include-patterns` | `LT_INCLUDE_PATTERNS` | [] | URL patterns to include (regex) |
-| exclude_patterns | `--exclude-patterns` | `LT_EXCLUDE_PATTERNS` | [] | URL patterns to exclude (regex) |
+| include_patterns | `--include-patterns` | `LT_INCLUDE_PATTERNS` | [] | Absolute full-URL regex ranges added to seed origins |
+| exclude_patterns | `--exclude-patterns` | `LT_EXCLUDE_PATTERNS` | [] | Substring regexes removed from the allowed URL set |
 | allowed_schemes | - | - | ["https://", "http://"] | Allowed URL schemes (config file only) |
 | **Authentication** |
 | auth.type | `--auth-type` | `LT_AUTH_TYPE` | "" | Authentication type: basic, bearer, api-key |
@@ -60,15 +60,15 @@ user_agent: "LinkTadoru/1.0"
 ignore_robots_txt: false
 follow_external_hosts: false # Stay on the seed hosts by default
 limit: 0                     # Stop after N pages (0 = unlimited)
-max_depth: 0                 # 0 = unlimited; N > 0 includes discovery depth N
+max_depth: 0                 # 0 = unlimited; positive N includes depth N
 max_response_size: 10485760  # Max response body size in bytes (10 MiB)
 
-# URL filtering (regex; double the backslashes in double-quoted YAML strings)
+# URL policy (Go regexp/RE2; single-quoted YAML keeps backslashes readable)
 include_patterns:
-  - "^https?://[^/]*httpbin\\.org/.*"
+  - '^https://search\.example/search(?:/.*)?(?:\?.*)?$'
 exclude_patterns:
-  - "\\.pdf$"
-  - "/admin/.*"
+  - '\.pdf$'
+  - '/admin/'
 
 # Custom HTTP headers
 headers:
@@ -81,6 +81,54 @@ database_path: "./linktadoru.db"
 # Logging (config file only, see the Logging section)
 log_level: "info"
 ```
+
+## URL Policy and Regular Expressions
+
+By default, a URL is allowed when its parsed origin (scheme, hostname, and
+effective port) exactly matches a persisted depth-0 seed origin. An
+`include_pattern` adds an absolute URL range, while an `exclude_pattern`
+subtracts from the resulting set. Excludes always win. The same decision is
+used for queued URLs, discovered links, redirects, and retries.
+
+Patterns use Go's standard `regexp` syntax (RE2):
+
+- `/` is an ordinary character and does not need escaping; patterns are not
+  JavaScript `/pattern/` literals.
+- `.` is a wildcard. Use `\.` for a literal dot in a hostname.
+- Includes are matched against the entire absolute URL. `^` and `$` are still
+  recommended for readability, but authorization does not depend on them.
+- Includes must identify an absolute URL range. Legacy relative includes such
+  as `/products/` fail at startup instead of silently changing meaning.
+- Excludes are substring matches, which is useful for `/private/` or query
+  parameter fragments.
+- Regex matching is case-sensitive and uses the stored absolute URL text;
+  unlike implicit-origin comparison, it does not lowercase the scheme or host.
+- Matching does not percent-decode URLs: `/ika/` does not match `/%69ka/`.
+- In YAML, single-quoted strings make backslashes easier to read.
+
+```yaml
+seed_urls:
+  - https://example.com/
+
+include_patterns:
+  # Add one trusted cross-origin subtree.
+  - '^https://hogehoge\.com/search(?:/.*)?(?:\?.*)?$'
+
+exclude_patterns:
+  - '/ika/'
+  - '[?&]page=[0-9]+(?:&|$)'
+```
+
+This allows `https://example.com/news/1` and
+`https://hogehoge.com/search/items?q=go`, but not
+`https://hogehoge.com/account` or an otherwise allowed URL containing
+`/ika/`. An include-only origin never receives authentication or configured
+custom headers. A broad include such as `^https?://.*$` has the same reach risk
+as `follow_external_hosts: true`.
+
+Before this change, includes narrowed an already host-limited set. Existing
+absolute cross-origin includes now actively add that range. Rewrite relative
+includes as absolute patterns (and/or excludes) before upgrading.
 
 ## Environment Variables
 
@@ -228,28 +276,11 @@ export LT_HEADER_X_API_VERSION="v1"
 
 ## Pattern Matching
 
-### Include Patterns
-Only URLs matching at least one include pattern will be crawled:
-
-```yaml
-include_patterns:
-  - "^https?://[^/]*httpbin\\.org/.*"     # Main domain
-  - "^https?://[^/]*\\.httpbin\\.org/.*"  # All subdomains
-  - ".*/products/.*"                      # Specific path
-```
-
-### Exclude Patterns
-URLs matching any exclude pattern will be skipped:
-
-```yaml
-exclude_patterns:
-  - "\\.pdf$"         # Skip PDFs
-  - "\\.jpg$"         # Skip images
-  - "/admin/.*"       # Skip admin section
-  - ".*\\?.*"         # Skip URLs with query strings
-```
-
-Invalid regexes are rejected at startup with a clear error message.
+`include_patterns` adds absolute full-URL ranges to the persisted seed-origin
+scope. `exclude_patterns` subtracts URLs from that combined scope and always
+wins. See [URL Policy and Regular Expressions](#url-policy-and-regular-expressions)
+for the matching rules, migration notes, and examples. Invalid patterns are
+rejected at startup.
 
 ## Performance Tuning
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -74,9 +74,9 @@ func init() {
 	rootCmd.Flags().DurationP("timeout", "t", 30*time.Second, "HTTP request timeout")
 	rootCmd.Flags().StringP("user-agent", "u", "LinkTadoru/1.0", "HTTP User-Agent header")
 	rootCmd.Flags().Bool("ignore-robots-txt", false, "Ignore robots.txt rules")
-	rootCmd.Flags().Bool("follow-external-hosts", false, "Allow crawling external hosts")
+	rootCmd.Flags().Bool("follow-external-hosts", false, "Allow all hosts with an allowed scheme (excludes still apply)")
 	rootCmd.Flags().IntP("limit", "l", 0, "Stop after N pages (0=unlimited)")
-	rootCmd.Flags().Int("max-depth", 0, "Maximum discovery depth (0=unlimited)")
+	rootCmd.Flags().Int("max-depth", 0, "Maximum first-discovery depth (0=unlimited, seeds=0)")
 	rootCmd.Flags().Int64("max-response-size", 10*1024*1024, "Max response body size in bytes")
 
 	// Authentication type flag
@@ -97,8 +97,8 @@ func init() {
 	rootCmd.Flags().StringSliceP("header", "H", []string{}, "Custom HTTP headers in 'Name: Value' format (use multiple times for multiple headers)")
 
 	// URL filtering flags
-	rootCmd.Flags().StringSlice("include-patterns", []string{}, "Regex patterns for URLs to include")
-	rootCmd.Flags().StringSlice("exclude-patterns", []string{}, "Regex patterns for URLs to exclude")
+	rootCmd.Flags().StringSlice("include-patterns", []string{}, "Absolute full-URL regex ranges to add")
+	rootCmd.Flags().StringSlice("exclude-patterns", []string{}, "Substring regex patterns to exclude")
 
 	// Database flags
 	rootCmd.Flags().StringP("database", "d", "./linktadoru.db", "Path to SQLite database file")
@@ -267,9 +267,6 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
-	if cfg.MaxDepth > 0 && len(cfg.SeedURLs) == 0 {
-		return fmt.Errorf("--max-depth requires seed URLs and a fresh database")
-	}
 
 	// Validate startup conditions: prevent running without URLs and without existing database
 	if len(cfg.SeedURLs) == 0 {
@@ -279,15 +276,14 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 				cfg.DatabasePath, os.Args[0])
 		}
 
-		// Database exists, but let's check if it has any queued items
+		// Database exists, but let's check if it has queued or retryable work.
 		// Create a temporary storage instance to check queue status
 		tempStorage, err := storage.NewSQLiteStorage(cfg.DatabasePath)
 		if err != nil {
 			return fmt.Errorf("failed to open database %s: %w", cfg.DatabasePath, err)
 		}
 
-		// Check if queue has any items (queued or processing)
-		hasWork, err := tempStorage.HasQueuedItems()
+		hasWork, err := tempStorage.HasResumableWork()
 		if err != nil {
 			if closeErr := tempStorage.Close(); closeErr != nil {
 				return fmt.Errorf("failed to check queue status: %w (close error: %v)", err, closeErr)
@@ -299,7 +295,7 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 		}
 
 		if !hasWork {
-			fmt.Printf("No URLs provided and no queued items found in database %s\n", cfg.DatabasePath)
+			fmt.Printf("No URLs provided and no resumable work found in database %s\n", cfg.DatabasePath)
 			fmt.Printf("Nothing to crawl. Exiting.\n")
 			return nil
 		}

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -266,29 +266,6 @@ func TestRunCrawlerStartupValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("BoundedCrawlRequiresSeedsBeforeEmptyDBExit", func(t *testing.T) {
-		viper.Reset()
-
-		dbPath := filepath.Join(tempDir, "bounded-empty.db")
-		emptyStore, err := storage.NewSQLiteStorage(dbPath)
-		if err != nil {
-			t.Fatalf("Failed to create test database: %v", err)
-		}
-		_ = emptyStore.Close()
-
-		cmd := &cobra.Command{}
-		cmd.Flags().Bool("show-config", false, "")
-		cmd.Flags().String("database", dbPath, "")
-		cmd.Flags().Int("max-depth", 2, "")
-		_ = viper.BindPFlag("database_path", cmd.Flags().Lookup("database"))
-		_ = viper.BindPFlag("max_depth", cmd.Flags().Lookup("max-depth"))
-
-		err = runCrawler(cmd, []string{})
-		if err == nil || !strings.Contains(err.Error(), "--max-depth requires seed URLs") {
-			t.Fatalf("bounded empty resume error = %v, want seed requirement", err)
-		}
-	})
-
 	t.Run("NoURLsDBWithQueue", func(t *testing.T) {
 		// Reset viper for each subtest
 		viper.Reset()

--- a/internal/crawler/audit_fixes_test.go
+++ b/internal/crawler/audit_fixes_test.go
@@ -84,14 +84,14 @@ func TestNewCrawlerRejectsInvalidPatterns(t *testing.T) {
 
 	cfg := base()
 	cfg.IncludePatterns = []string{"["}
-	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "include_patterns") {
-		t.Errorf("invalid include pattern: err = %v, want include_patterns compile error", err)
+	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "include pattern") {
+		t.Errorf("invalid include pattern: err = %v, want include pattern error", err)
 	}
 
 	cfg = base()
 	cfg.ExcludePatterns = []string{"(unclosed"}
-	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "exclude_patterns") {
-		t.Errorf("invalid exclude pattern: err = %v, want exclude_patterns compile error", err)
+	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "exclude pattern") {
+		t.Errorf("invalid exclude pattern: err = %v, want exclude pattern error", err)
 	}
 }
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -24,13 +23,7 @@ type DefaultCrawler struct {
 	processor    PageProcessor
 	rateLimiter  *RateLimiter
 	robotsParser *RobotsParser
-	allowedHosts []string // Hosts allowed for crawling (from seed URLs)
-
-	// Include/exclude patterns compiled once at construction. Compiling here
-	// (a) rejects an invalid pattern at startup instead of silently never
-	// matching it, and (b) avoids recompiling every pattern for every URL.
-	includePatterns []*regexp.Regexp
-	excludePatterns []*regexp.Regexp
+	urlPolicy    *urlPolicy
 
 	// State
 	stats      CrawlStats
@@ -99,117 +92,42 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 	}
 
 	// Initialize components
-	processor := NewPageProcessorWithConfig(httpClient, config.AllowedSchemes, config.FollowExternalHosts)
+	processor := NewPageProcessorWithConfig(httpClient, config.AllowedSchemes, true)
 	rateLimiter := NewRateLimiter(time.Duration(config.RequestDelay * float64(time.Second)))
 	robotsParser := NewRobotsParser(httpClient, config.IgnoreRobotsTxt)
 
-	// Extract allowed hosts from seed URLs for same-host filtering
-	allowedHosts := make([]string, 0, len(config.SeedURLs))
-	for _, seedURL := range config.SeedURLs {
-		if parsedURL, err := url.Parse(seedURL); err == nil {
-			host := parsedURL.Scheme + "://" + parsedURL.Host
-			// Avoid duplicates
-			found := false
-			for _, existing := range allowedHosts {
-				if existing == host {
-					found = true
-					break
-				}
-			}
-			if !found {
-				allowedHosts = append(allowedHosts, host)
-			}
-		}
-	}
-
-	// Compile URL filter patterns up front so an invalid regex fails the run
-	// loudly instead of being silently ignored on every URL.
-	includePatterns, err := compilePatterns(config.IncludePatterns)
+	policy, err := newURLPolicy(
+		config.AllowedSchemes,
+		config.IncludePatterns,
+		config.ExcludePatterns,
+		config.FollowExternalHosts,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("invalid include_patterns: %w", err)
+		return nil, fmt.Errorf("invalid URL policy: %w", err)
 	}
-	excludePatterns, err := compilePatterns(config.ExcludePatterns)
-	if err != nil {
-		return nil, fmt.Errorf("invalid exclude_patterns: %w", err)
+	if len(config.IncludePatterns) > 0 {
+		slog.Warn("include_patterns add URL ranges; seed origins remain allowed; use exclude_patterns to narrow them")
 	}
 
 	crawler := &DefaultCrawler{
-		config:          config,
-		storage:         storage,
-		httpClient:      httpClient,
-		processor:       processor,
-		rateLimiter:     rateLimiter,
-		robotsParser:    robotsParser,
-		allowedHosts:    allowedHosts,
-		includePatterns: includePatterns,
-		excludePatterns: excludePatterns,
+		config:       config,
+		storage:      storage,
+		httpClient:   httpClient,
+		processor:    processor,
+		rateLimiter:  rateLimiter,
+		robotsParser: robotsParser,
+		urlPolicy:    policy,
 		stats: CrawlStats{
 			StartTime: time.Now(),
 		},
 	}
 
-	// Redirects must clear the same host filter as newly discovered URLs.
-	// Checking only the initial URL lets a 302 walk the crawler onto a host it
-	// was never allowed to reach.
+	// Redirects use the same URL policy as claimed and discovered URLs.
 	httpClient.SetRedirectPolicy(func(u *url.URL) bool {
-		return crawler.isAllowedHost(u.String())
+		return crawler.urlPolicy.allows(u.String())
 	})
 
 	return crawler, nil
-}
-
-// compilePatterns compiles a list of regex patterns, reporting the offending
-// pattern on failure.
-func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
-	compiled := make([]*regexp.Regexp, 0, len(patterns))
-	for _, p := range patterns {
-		re, err := regexp.Compile(p)
-		if err != nil {
-			return nil, fmt.Errorf("pattern %q: %w", p, err)
-		}
-		compiled = append(compiled, re)
-	}
-	return compiled, nil
-}
-
-// isAllowedHost checks if the given URL's host is allowed for crawling
-func (c *DefaultCrawler) isAllowedHost(targetURL string) bool {
-	// First check if URL has an allowed scheme
-	if !c.isAllowedScheme(targetURL) {
-		return false
-	}
-
-	// If external hosts are allowed, accept any valid scheme
-	if c.config.FollowExternalHosts {
-		return true
-	}
-
-	// Check if URL starts with any allowed host prefix
-	for _, allowedHost := range c.allowedHosts {
-		// Allow exact match or prefix with trailing slash
-		if targetURL == allowedHost || strings.HasPrefix(targetURL, allowedHost+"/") {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isAllowedScheme checks if the URL has an allowed scheme
-func (c *DefaultCrawler) isAllowedScheme(targetURL string) bool {
-	// Use configured allowed schemes, fallback to defaults if empty
-	allowedSchemes := c.config.AllowedSchemes
-	if len(allowedSchemes) == 0 {
-		allowedSchemes = []string{"https://", "http://"}
-	}
-
-	for _, scheme := range allowedSchemes {
-		if strings.HasPrefix(targetURL, scheme) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // Start starts the crawling process
@@ -222,17 +140,12 @@ func (c *DefaultCrawler) isAllowedScheme(targetURL string) bool {
 func (c *DefaultCrawler) Start(ctx context.Context, seedURLs []string) error {
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	defer c.cancel()
-	if c.config.MaxDepth > 0 {
-		if len(seedURLs) == 0 {
-			return fmt.Errorf("--max-depth requires seed URLs and a fresh database")
-		}
-		hasPages, err := c.storage.HasAnyPages()
-		if err != nil {
-			return fmt.Errorf("failed to inspect database before bounded crawl: %w", err)
-		}
-		if hasPages {
-			return fmt.Errorf("--max-depth requires a fresh database")
-		}
+
+	if err := c.urlPolicy.validateExplicitURLs(seedURLs); err != nil {
+		return err
+	}
+	if len(seedURLs) == 0 && c.hasConfiguredCredentials() {
+		return fmt.Errorf("seedless resume cannot use authentication or custom headers; supply the seed URLs again")
 	}
 
 	// Reset rows left in 'processing' by a previous interrupted run back to
@@ -260,6 +173,27 @@ func (c *DefaultCrawler) Start(ctx context.Context, seedURLs []string) error {
 	} else {
 		slog.Info("Starting crawler - resuming from existing queue")
 	}
+
+	depthZeroURLs, err := c.storage.GetDepthZeroURLs()
+	if err != nil {
+		return fmt.Errorf("failed to restore URL policy roots: %w", err)
+	}
+	if err := c.urlPolicy.setImplicitOrigins(depthZeroURLs); err != nil {
+		return fmt.Errorf("failed to restore URL policy roots: %w", err)
+	}
+	credentialOrigins, err := c.urlPolicy.origins(seedURLs)
+	if err != nil {
+		return fmt.Errorf("failed to build credential policy: %w", err)
+	}
+	// This policy is installed before workers start and is read-only afterward.
+	c.httpClient.SetCredentialPolicy(func(u *url.URL) bool {
+		_, origin, err := c.urlPolicy.parse(u.String())
+		if err != nil {
+			return false
+		}
+		_, ok := credentialOrigins[origin]
+		return ok
+	})
 
 	// Step 2: Start workers after queue is populated
 	for i := 0; i < c.config.Concurrency; i++ {
@@ -418,6 +352,16 @@ func (c *DefaultCrawler) workerSleep() {
 
 // processURLItem processes a single URL item from the queue
 func (c *DefaultCrawler) processURLItem(id int, item *URLItem) {
+	// Authorization precedes robots.txt because that lookup is itself a
+	// network request to the claimed URL's origin.
+	if !c.urlPolicy.allows(item.URL) {
+		slog.Info("URL denied by URL policy", "worker_id", id, "url", item.URL)
+		if err := c.storage.SavePageSkipped(item.ID, "url_policy_denied", "Denied by URL policy"); err != nil {
+			slog.Error("Worker failed to save URL policy skip", "worker_id", id, "error", err)
+		}
+		return
+	}
+
 	// Check robots.txt
 	if !c.shouldProcessURL(id, item) {
 		return
@@ -584,7 +528,7 @@ func (c *DefaultCrawler) processNewURLs(id int, links []*LinkData, parent *URLIt
 
 	var newURLs []string
 	for _, link := range links {
-		if link.LinkType != "internal" || !c.shouldCrawlURL(link.TargetURL) {
+		if !c.urlPolicy.allows(link.TargetURL) {
 			continue
 		}
 		newURLs = append(newURLs, link.TargetURL)
@@ -631,35 +575,18 @@ func (c *DefaultCrawler) statsReporter() {
 
 // Helper methods
 
-// shouldCrawlURL determines if a URL should be crawled based on include/exclude patterns
-func (c *DefaultCrawler) shouldCrawlURL(urlStr string) bool {
-	// First check if the host is allowed for crawling
-	if !c.isAllowedHost(urlStr) {
-		return false
+func (c *DefaultCrawler) hasConfiguredCredentials() bool {
+	if len(c.config.Headers) > 0 {
+		return true
 	}
-
-	// If include patterns are specified, URL must match at least one
-	if len(c.includePatterns) > 0 {
-		matched := false
-		for _, re := range c.includePatterns {
-			if re.MatchString(urlStr) {
-				matched = true
-				break
-			}
-		}
-		if !matched {
-			return false
-		}
+	if username, password := c.config.GetBasicAuthCredentials(); username != "" || password != "" {
+		return true
 	}
-
-	// Check exclude patterns - URL must not match any
-	for _, re := range c.excludePatterns {
-		if re.MatchString(urlStr) {
-			return false
-		}
+	if c.config.GetBearerToken() != "" {
+		return true
 	}
-
-	return true
+	header, value := c.config.GetAPIKeyCredentials()
+	return header != "" || value != ""
 }
 
 func (c *DefaultCrawler) incrementCrawledCount() {

--- a/internal/crawler/http_client.go
+++ b/internal/crawler/http_client.go
@@ -46,6 +46,10 @@ type HTTPClient struct {
 	// redirectPolicy decides whether a redirect target may be followed.
 	// Nil allows every target, bounded only by the hop limit.
 	redirectPolicy func(*url.URL) bool
+	// credentialPolicy is separate from URL authorization. It limits configured
+	// credentials and custom headers to origins explicitly supplied as seeds in
+	// the current invocation.
+	credentialPolicy func(*url.URL) bool
 }
 
 // HTTPMetrics contains performance metrics for an HTTP request
@@ -102,6 +106,13 @@ func (h *HTTPClient) SetRedirectPolicy(allow func(*url.URL) bool) {
 	h.redirectPolicy = allow
 }
 
+// SetCredentialPolicy installs the origin predicate for configured secret
+// headers. A nil policy preserves the standalone HTTPClient's historical
+// behavior; the crawler always installs a policy before starting workers.
+func (h *HTTPClient) SetCredentialPolicy(allow func(*url.URL) bool) {
+	h.credentialPolicy = allow
+}
+
 // checkRedirect gates redirect hops. It runs before the next request is sent,
 // so a rejected target is never contacted. On top of the hop limit it enforces
 // the redirect policy and drops credentials once the origin changes, so a
@@ -115,13 +126,21 @@ func (h *HTTPClient) checkRedirect(req *http.Request, via []*http.Request) error
 		return fmt.Errorf("%w: %s", ErrRedirectNotAllowed, req.URL.String())
 	}
 
-	// Compare against the originating request: credentials belong to the
-	// origin they were configured for and must not follow the crawler off it.
-	// Go's built-in redirect policy does not cover the configured API-key
-	// header or arbitrary custom headers, so every crawler credential is
-	// removed here at an explicit origin boundary.
-	if len(via) > 0 && !sameOrigin(via[0].URL, req.URL) {
-		h.stripCredentialHeaders(req.Header)
+	// Credential removal is monotonic for the redirect chain. Once any hop has
+	// left the initial origin, a later A -> B -> A redirect must not restore the
+	// initial credentials when it returns to A.
+	if len(via) > 0 {
+		origin := via[0].URL
+		leftOrigin := !sameOrigin(origin, req.URL)
+		for _, previous := range via[1:] {
+			if !sameOrigin(origin, previous.URL) {
+				leftOrigin = true
+				break
+			}
+		}
+		if leftOrigin {
+			h.stripCredentialHeaders(req.Header)
+		}
 	}
 
 	return nil
@@ -129,7 +148,9 @@ func (h *HTTPClient) checkRedirect(req *http.Request, via []*http.Request) error
 
 // sameOrigin reports whether two URLs share a scheme and host (including port).
 func sameOrigin(a, b *url.URL) bool {
-	return a.Scheme == b.Scheme && a.Host == b.Host
+	aOrigin, aErr := originKey(a)
+	bOrigin, bErr := originKey(b)
+	return aErr == nil && bErr == nil && aOrigin == bOrigin
 }
 
 // stripCredentialHeaders removes every header that carries a secret.
@@ -227,6 +248,9 @@ func (h *HTTPClient) Get(ctx context.Context, url string) (*HTTPResponse, error)
 	// Set custom headers
 	for name, value := range h.customHeaders {
 		req.Header.Set(name, value)
+	}
+	if h.credentialPolicy != nil && !h.credentialPolicy(req.URL) {
+		h.stripCredentialHeaders(req.Header)
 	}
 
 	// Setup performance tracking

--- a/internal/crawler/integration_test.go
+++ b/internal/crawler/integration_test.go
@@ -185,10 +185,6 @@ func (e *EnhancedMockStorage) SavePageSkipped(id int, reason, message string) er
 	return nil
 }
 
-func (e *EnhancedMockStorage) GetRetryablePages(maxRetries int) ([]URLItem, error) {
-	return nil, nil
-}
-
 func (e *EnhancedMockStorage) RequeueErrorPages(maxRetries int) (int, error) {
 	return 0, nil
 }
@@ -240,10 +236,6 @@ func (e *ErrorMockStorage) GetNextFromQueue() (*URLItem, error) {
 
 func (e *ErrorMockStorage) SavePageSkipped(id int, reason, message string) error {
 	return nil
-}
-
-func (e *ErrorMockStorage) GetRetryablePages(maxRetries int) ([]URLItem, error) {
-	return nil, nil
 }
 
 func (e *ErrorMockStorage) RequeueErrorPages(maxRetries int) (int, error) {
@@ -394,10 +386,6 @@ func (l *LimitTestStorage) SavePageSkipped(id int, reason, message string) error
 	return nil
 }
 
-func (l *LimitTestStorage) GetRetryablePages(maxRetries int) ([]URLItem, error) {
-	return nil, nil
-}
-
 func (l *LimitTestStorage) RequeueErrorPages(maxRetries int) (int, error) {
 	return 0, nil
 }
@@ -445,17 +433,13 @@ func TestSameHostFiltering(t *testing.T) {
 		t.Fatalf("Failed to create crawler: %v", err)
 	}
 
-	// Check allowed hosts were set correctly
-	expectedHost := server1.URL
-	if len(crawler.allowedHosts) != 1 || crawler.allowedHosts[0] != expectedHost {
-		t.Errorf("Expected allowedHosts to contain [%s], got %v", expectedHost, crawler.allowedHosts)
+	if err := crawler.urlPolicy.setImplicitOrigins([]string{server1.URL}); err != nil {
+		t.Fatal(err)
 	}
-
-	// Test host filtering logic
-	if !crawler.isAllowedHost(server1.URL + "/page1") {
+	if !crawler.urlPolicy.allows(server1.URL + "/page1") {
 		t.Errorf("Same host URL should be allowed")
 	}
-	if crawler.isAllowedHost(server2.URL + "/external") {
+	if crawler.urlPolicy.allows(server2.URL + "/external") {
 		t.Errorf("External host URL should be blocked")
 	}
 }
@@ -495,10 +479,10 @@ func TestExternalHostsEnabled(t *testing.T) {
 	}
 
 	// Test that both internal and external hosts are allowed
-	if !crawler.isAllowedHost(server1.URL + "/page1") {
+	if !crawler.urlPolicy.allows(server1.URL + "/page1") {
 		t.Errorf("Same host URL should be allowed")
 	}
-	if !crawler.isAllowedHost(server2.URL + "/external") {
+	if !crawler.urlPolicy.allows(server2.URL + "/external") {
 		t.Errorf("External host URL should be allowed when follow_external_hosts is true")
 	}
 }
@@ -510,10 +494,6 @@ type HostFilteringTestStorage struct {
 
 func (h *HostFilteringTestStorage) SavePageSkipped(id int, reason, message string) error {
 	return nil
-}
-
-func (h *HostFilteringTestStorage) GetRetryablePages(maxRetries int) ([]URLItem, error) {
-	return nil, nil
 }
 
 func (h *HostFilteringTestStorage) RequeueErrorPages(maxRetries int) (int, error) {

--- a/internal/crawler/interfaces.go
+++ b/internal/crawler/interfaces.go
@@ -40,19 +40,16 @@ type Storage interface {
 	GetQueueStatus() (pending int, processing int, completed int, errors int, err error)
 	CleanupStaleProcessing(timeout time.Duration) error
 	HasQueuedItems() (bool, error) // Check if queue has any work items (pending or processing)
-	HasAnyPages() (bool, error)
+	HasResumableWork() (bool, error)
 	ValidateDepthTracking(seedURLs []string) error
+	GetDepthZeroURLs() ([]string, error)
 
 	// Retry management
-	GetRetryablePages(maxRetries int) ([]URLItem, error)
 	RequeueErrorPages(maxRetries int) (int, error)
 
 	// Meta-data management
 	GetMeta(key string) (string, error)
 	SetMeta(key, value string) error
-
-	// URL status check (any status)
-	GetURLStatus(url string) (status string, exists bool)
 
 	// Database lifecycle
 	Close() error

--- a/internal/crawler/issue46_integration_test.go
+++ b/internal/crawler/issue46_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"regexp"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -106,14 +108,35 @@ func TestCrawlRespectsExcludePatterns(t *testing.T) {
 // Test C (include): when include_patterns is set, a non-matching URL is recorded
 // as 'discovered' but never crawled.
 func TestCrawlRespectsIncludePatterns(t *testing.T) {
-	cfg := baseCfg()
-	cfg.IncludePatterns = []string{"/articles/"}
-	store, base := runCrawl(t, cfg, []string{"/articles/ok", "/other/no"})
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>external</body></html>"))
+	}))
+	defer external.Close()
 
-	if got, _ := statusOf(t, store, base+"/articles/ok"); got != "completed" {
+	seed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<a href="` + external.URL + `/articles/ok">ok</a><a href="` + external.URL + `/other/no">no</a>`))
+	}))
+	defer seed.Close()
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{seed.URL}
+	cfg.IncludePatterns = []string{`^` + regexp.QuoteMeta(external.URL) + `/articles/ok$`}
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Stop() }()
+	if err := c.Start(context.Background(), cfg.SeedURLs); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := statusOf(t, store, external.URL+"/articles/ok"); got != "completed" {
 		t.Errorf("/articles/ok status = %q, want completed", got)
 	}
-	got, exists := statusOf(t, store, base+"/other/no")
+	got, exists := statusOf(t, store, external.URL+"/other/no")
 	if !exists {
 		t.Fatal("/other/no should exist as a link-graph node")
 	}
@@ -170,7 +193,7 @@ func TestNetworkErrorDoesNotHangAndMarksTerminal(t *testing.T) {
 // Regression: a malformed seed URL (one that fails url.Parse in the rate
 // limiter) must be driven to a terminal state, not left in 'processing' where it
 // would hang the HasQueuedItems()-based worker exit.
-func TestMalformedURLDoesNotHangAndMarksTerminal(t *testing.T) {
+func TestMalformedSeedURLFailsBeforeCrawl(t *testing.T) {
 	// A control character makes net/url.Parse fail.
 	badURL := "http://example.com/\x7f"
 
@@ -183,20 +206,11 @@ func TestMalformedURLDoesNotHangAndMarksTerminal(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = c.Stop() })
 
-	done := make(chan error, 1)
-	go func() { done <- c.Start(context.Background(), cfg.SeedURLs) }()
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("Start returned error: %v", err)
-		}
-	case <-time.After(15 * time.Second):
-		t.Fatal("crawler hung on a malformed seed URL (row stuck in 'processing')")
+	if err := c.Start(context.Background(), cfg.SeedURLs); err == nil {
+		t.Fatal("malformed seed URL was accepted")
 	}
-
-	if got, _ := statusOf(t, store, badURL); got != "error" {
-		t.Errorf("malformed seed status = %q, want error (terminal)", got)
+	if _, exists := statusOf(t, store, badURL); exists {
+		t.Fatal("malformed seed URL was written before validation")
 	}
 }
 
@@ -245,6 +259,49 @@ func TestStaleProcessingRowDoesNotHangOnResume(t *testing.T) {
 	// The stale row must have been reset and then driven to a terminal state.
 	if got, _ := statusOf(t, store, deadURL); got == "processing" || got == "pending" {
 		t.Errorf("stale row status = %q, want a terminal state", got)
+	}
+}
+
+func TestDeniedQueuedURLIsSkippedBeforeAnyNetworkRequest(t *testing.T) {
+	var deniedHits atomic.Int32
+	denied := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deniedHits.Add(1)
+		_, _ = w.Write([]byte("must not be contacted"))
+	}))
+	defer denied.Close()
+
+	store := newStore(t)
+	const root = "https://allowed.example/root"
+	if err := store.AddSeeds([]string{root}); err != nil {
+		t.Fatal(err)
+	}
+	rootItem, err := store.GetNextFromQueue()
+	if err != nil || rootItem == nil {
+		t.Fatalf("claim root: item=%v err=%v", rootItem, err)
+	}
+	if err := store.SavePageResult(rootItem.ID, &crawler.PageData{URL: root, HTTPHeaders: map[string]string{}, CrawledAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddToQueue([]string{denied.URL + "/page"}, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := baseCfg()
+	cfg.SeedURLs = nil
+	cfg.IgnoreRobotsTxt = false
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Stop() }()
+	if err := c.Start(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := deniedHits.Load(); got != 0 {
+		t.Fatalf("denied origin received %d requests, want zero", got)
+	}
+	if got, _ := statusOf(t, store, denied.URL+"/page"); got != "skipped" {
+		t.Fatalf("denied queued URL status = %q, want skipped", got)
 	}
 }
 

--- a/internal/crawler/limit_test.go
+++ b/internal/crawler/limit_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 // MockStorage implements Storage interface for testing
-type MockStorage struct{}
+type MockStorage struct {
+	depthZero []string
+}
 
 type seedRecordingStorage struct {
 	MockStorage
@@ -67,6 +69,7 @@ func (m *MockStorage) Close() error {
 }
 
 func (m *MockStorage) AddSeeds(urls []string) error {
+	m.depthZero = append(m.depthZero, urls...)
 	return nil
 }
 
@@ -110,15 +113,11 @@ func (m *MockStorage) SetMeta(key, value string) error {
 	return nil
 }
 
-func (m *MockStorage) GetURLStatus(url string) (status string, exists bool) {
-	return "", false
-}
-
 func (m *MockStorage) HasQueuedItems() (bool, error) {
 	return false, nil
 }
 
-func (m *MockStorage) HasAnyPages() (bool, error) {
+func (m *MockStorage) HasResumableWork() (bool, error) {
 	return false, nil
 }
 
@@ -126,12 +125,12 @@ func (m *MockStorage) ValidateDepthTracking(seedURLs []string) error {
 	return nil
 }
 
-func (m *MockStorage) SavePageSkipped(id int, reason, message string) error {
-	return nil
+func (m *MockStorage) GetDepthZeroURLs() ([]string, error) {
+	return append([]string(nil), m.depthZero...), nil
 }
 
-func (m *MockStorage) GetRetryablePages(maxRetries int) ([]URLItem, error) {
-	return nil, nil
+func (m *MockStorage) SavePageSkipped(id int, reason, message string) error {
+	return nil
 }
 
 func (m *MockStorage) RequeueErrorPages(maxRetries int) (int, error) {

--- a/internal/crawler/minimal_controls_integration_test.go
+++ b/internal/crawler/minimal_controls_integration_test.go
@@ -291,7 +291,7 @@ func TestPermanentHTTPStatusIsNotRetried(t *testing.T) {
 	}
 }
 
-func TestMaxDepthOneRejectsMissingSeeds(t *testing.T) {
+func TestMaxDepthOneEmptyResumeSucceeds(t *testing.T) {
 	store := newStore(t)
 	cfg := minimalConfig(nil, 1, 1)
 	c, err := crawler.NewCrawler(cfg, store)
@@ -299,24 +299,139 @@ func TestMaxDepthOneRejectsMissingSeeds(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = c.Stop() }()
-	if err := c.Start(context.Background(), nil); err == nil {
-		t.Fatal("max_depth=1 run without seeds was accepted")
+	if err := c.Start(context.Background(), nil); err != nil {
+		t.Fatalf("empty resume failed: %v", err)
 	}
 }
 
-func TestMaxDepthOneRejectsNonEmptyDatabase(t *testing.T) {
+func TestMaxDepthOneResumesPersistedDepthZeroQueue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer server.Close()
+
 	store := newStore(t)
-	const seed = "https://example.com"
-	if err := store.AddToQueue([]string{seed}, 0); err != nil {
+	if err := store.AddToQueue([]string{server.URL}, 0); err != nil {
 		t.Fatal(err)
 	}
-	cfg := minimalConfig([]string{seed}, 1, 1)
+	cfg := minimalConfig(nil, 1, 1)
 	c, err := crawler.NewCrawler(cfg, store)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = c.Stop() }()
-	if err := c.Start(context.Background(), cfg.SeedURLs); err == nil {
-		t.Fatal("max_depth=1 accepted a non-empty database")
+	if err := c.Start(context.Background(), nil); err != nil {
+		t.Fatalf("seedless resume failed: %v", err)
+	}
+	if got, _ := statusOf(t, store, server.URL); got != "completed" {
+		t.Fatalf("resumed status = %q, want completed", got)
+	}
+}
+
+func TestSeedlessResumeRetriesPersistedErrorAtItsOriginalDepth(t *testing.T) {
+	var childRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/child" {
+			childRequests.Add(1)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer server.Close()
+
+	store := newStore(t)
+	root := server.URL + "/root"
+	child := server.URL + "/child"
+	if err := store.AddSeeds([]string{root}); err != nil {
+		t.Fatal(err)
+	}
+	item, err := store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim root: item=%+v err=%v", item, err)
+	}
+	if err := store.SavePageResult(item.ID, &crawler.PageData{
+		URL:         root,
+		HTTPHeaders: map[string]string{},
+		CrawledAt:   time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddToQueue([]string{child}, 1); err != nil {
+		t.Fatal(err)
+	}
+	item, err = store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim child: item=%+v err=%v", item, err)
+	}
+	if err := store.SavePageError(item.ID, "network_error", "temporary"); err != nil {
+		t.Fatal(err)
+	}
+
+	startCrawler(t, minimalConfig(nil, 1, 1), store)
+	if got := childRequests.Load(); got != 1 {
+		t.Fatalf("retried child requests = %d, want 1", got)
+	}
+	if got, _ := statusOf(t, store, child); got != "completed" {
+		t.Fatalf("retried child status = %q, want completed", got)
+	}
+}
+
+func TestAuthenticatedSeedlessResumeFailsClosed(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+	}))
+	defer server.Close()
+
+	store := newStore(t)
+	if err := store.AddSeeds([]string{server.URL}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := minimalConfig(nil, 1, 1)
+	cfg.Headers = []string{"X-Secret: value"}
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Stop() }()
+	if err := c.Start(context.Background(), nil); err == nil {
+		t.Fatal("authenticated seedless resume was accepted")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("seedless authenticated resume made %d requests", got)
+	}
+}
+
+func TestResumeDrainsAlreadyAdmittedRowsBeyondCurrentBound(t *testing.T) {
+	var deepRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/deep" {
+			deepRequests.Add(1)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer server.Close()
+
+	store := newStore(t)
+	root := server.URL + "/root"
+	if err := store.AddSeeds([]string{root}); err != nil {
+		t.Fatal(err)
+	}
+	item, err := store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim root: item=%+v err=%v", item, err)
+	}
+	if err := store.SavePageResult(item.ID, &crawler.PageData{URL: root, HTTPHeaders: map[string]string{}, CrawledAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddToQueue([]string{server.URL + "/deep"}, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	startCrawler(t, minimalConfig(nil, 1, 1), store)
+	if got := deepRequests.Load(); got != 1 {
+		t.Fatalf("already admitted depth-2 row fetched %d times, want 1", got)
 	}
 }

--- a/internal/crawler/redirect_test.go
+++ b/internal/crawler/redirect_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,7 +37,106 @@ func newRedirectTestCrawler(t *testing.T, seedURL string, followExternal bool) *
 	if err != nil {
 		t.Fatalf("NewCrawler failed: %v", err)
 	}
+	if err := crawler.urlPolicy.setImplicitOrigins([]string{seedURL}); err != nil {
+		t.Fatalf("setImplicitOrigins failed: %v", err)
+	}
 	return crawler
+}
+
+type credentialWiringStorage struct {
+	MockStorage
+	items []*URLItem
+	next  int
+}
+
+func (s *credentialWiringStorage) AddSeeds(urls []string) error {
+	return s.MockStorage.AddSeeds(urls)
+}
+
+func (s *credentialWiringStorage) GetNextFromQueue() (*URLItem, error) {
+	if s.next >= len(s.items) {
+		return nil, nil
+	}
+	item := s.items[s.next]
+	s.next++
+	return item, nil
+}
+
+func runCredentialWiringCrawl(t *testing.T, seed, queued string, includes []string) {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.SeedURLs = []string{seed}
+	cfg.IncludePatterns = includes
+	cfg.Concurrency = 1
+	cfg.RequestDelay = 0
+	cfg.IgnoreRobotsTxt = true
+	cfg.Auth = &config.Auth{
+		Type:   config.BearerAuthType,
+		Bearer: &config.BearerAuth{Token: "bearer-secret"},
+	}
+	cfg.Headers = []string{
+		"X-Api-Key: api-secret",
+		"Cookie: session=secret",
+		"X-Internal-Token: custom-secret",
+	}
+	store := &credentialWiringStorage{items: []*URLItem{{ID: 1, URL: queued, Depth: 0}}}
+	crawler, err := NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = crawler.Stop() }()
+	if err := crawler.Start(context.Background(), cfg.SeedURLs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStartSeparatesAccumulatedRootsFromCurrentCredentialOrigins(t *testing.T) {
+	var oldHeaders, currentHeaders http.Header
+	oldRoot := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		oldHeaders = r.Header.Clone()
+		_, _ = w.Write([]byte("old"))
+	}))
+	defer oldRoot.Close()
+	currentSeed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		currentHeaders = r.Header.Clone()
+		_, _ = w.Write([]byte("current"))
+	}))
+	defer currentSeed.Close()
+
+	cfg := config.DefaultConfig()
+	cfg.SeedURLs = []string{currentSeed.URL}
+	cfg.Concurrency = 1
+	cfg.RequestDelay = 0
+	cfg.IgnoreRobotsTxt = true
+	cfg.Auth = &config.Auth{
+		Type:   config.BearerAuthType,
+		Bearer: &config.BearerAuth{Token: "bearer-secret"},
+	}
+	store := &credentialWiringStorage{
+		MockStorage: MockStorage{depthZero: []string{oldRoot.URL}},
+		items: []*URLItem{
+			{ID: 1, URL: oldRoot.URL, Depth: 0},
+			{ID: 2, URL: currentSeed.URL, Depth: 0},
+		},
+	}
+	crawler, err := NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = crawler.Stop() }()
+	if err := crawler.Start(context.Background(), cfg.SeedURLs); err != nil {
+		t.Fatal(err)
+	}
+
+	if oldHeaders == nil || currentHeaders == nil {
+		t.Fatalf("accumulated roots were not both fetched: old=%v current=%v", oldHeaders != nil, currentHeaders != nil)
+	}
+	if got := oldHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("credential reached old accumulated root: %q", got)
+	}
+	if got := currentHeaders.Get("Authorization"); got == "" {
+		t.Fatal("credential missing from current explicit seed origin")
+	}
 }
 
 // A redirect that stays on the seed host is followed as before.
@@ -152,6 +252,86 @@ func TestRedirectDropsBearerAuthorization(t *testing.T) {
 	}
 	if v := got.Get("Authorization"); v != "" {
 		t.Errorf("Authorization leaked to the external host: %q", v)
+	}
+}
+
+func TestStartWiresCredentialPolicyForDirectIncludeOnlyRequest(t *testing.T) {
+	var got http.Header
+	includeOnly := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer includeOnly.Close()
+
+	include := `^` + regexp.QuoteMeta(includeOnly.URL) + `/page$`
+	runCredentialWiringCrawl(t, "https://seed.example/start", includeOnly.URL+"/page", []string{include})
+
+	for _, name := range []string{"Authorization", "X-Api-Key", "X-Internal-Token", "Cookie"} {
+		if value := got.Get(name); value != "" {
+			t.Errorf("%s reached include-only origin: %q", name, value)
+		}
+	}
+}
+
+func TestStartWiresMonotonicCredentialPolicyAcrossABARedirect(t *testing.T) {
+	var aURL string
+	var initialA, atB, returnedA http.Header
+
+	b := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atB = r.Header.Clone()
+		http.Redirect(w, r, aURL+"/return", http.StatusFound)
+	}))
+	defer b.Close()
+
+	a := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			initialA = r.Header.Clone()
+			http.Redirect(w, r, b.URL+"/bounce", http.StatusFound)
+		case "/return":
+			returnedA = r.Header.Clone()
+			_, _ = w.Write([]byte("ok"))
+		}
+	}))
+	defer a.Close()
+	aURL = a.URL
+
+	include := `^` + regexp.QuoteMeta(b.URL) + `/bounce$`
+	runCredentialWiringCrawl(t, a.URL+"/start", a.URL+"/start", []string{include})
+
+	secretHeaders := []string{"Authorization", "X-Api-Key", "Cookie", "X-Internal-Token"}
+	for _, name := range secretHeaders {
+		if initialA.Get(name) == "" {
+			t.Errorf("%s missing from initial seed-origin request", name)
+		}
+		if value := atB.Get(name); value != "" {
+			t.Errorf("%s leaked at B: %q", name, value)
+		}
+		if value := returnedA.Get(name); value != "" {
+			t.Errorf("%s reappeared after A-B-A redirect: %q", name, value)
+		}
+	}
+}
+
+func TestStartKeepsCredentialsOnSameOriginRedirect(t *testing.T) {
+	var initial, redirected http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			initial = r.Header.Clone()
+			http.Redirect(w, r, "/return", http.StatusFound)
+		case "/return":
+			redirected = r.Header.Clone()
+			_, _ = w.Write([]byte("ok"))
+		}
+	}))
+	defer server.Close()
+
+	runCredentialWiringCrawl(t, server.URL+"/start", server.URL+"/start", nil)
+	for _, name := range []string{"Authorization", "X-Api-Key", "Cookie", "X-Internal-Token"} {
+		if initial.Get(name) == "" || redirected.Get(name) == "" {
+			t.Errorf("%s was not retained on same-origin redirect", name)
+		}
 	}
 }
 

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -1,627 +1,89 @@
 package crawler
 
-import (
-	"net/url"
-	"regexp"
-	"testing"
+import "testing"
 
-	"github.com/masahif/linktadoru/internal/config"
-)
-
-// mustCompilePatterns compiles URL filter patterns for tests that construct
-// DefaultCrawler directly instead of going through NewCrawler.
-func mustCompilePatterns(t *testing.T, patterns []string) []*regexp.Regexp {
-	t.Helper()
-	compiled, err := compilePatterns(patterns)
+func TestURLPolicyImplicitOriginAndExclude(t *testing.T) {
+	policy, err := newURLPolicy(
+		[]string{"https://", "http://"},
+		nil,
+		[]string{`/ika/`},
+		false,
+	)
 	if err != nil {
-		t.Fatalf("failed to compile patterns %v: %v", patterns, err)
+		t.Fatal(err)
 	}
-	return compiled
-}
+	if err := policy.setImplicitOrigins([]string{"https://example.com/seed"}); err != nil {
+		t.Fatal(err)
+	}
 
-func TestShouldCrawlURL(t *testing.T) {
 	tests := []struct {
-		name            string
-		includePatterns []string
-		excludePatterns []string
-		url             string
-		expected        bool
+		url  string
+		want bool
 	}{
-		{
-			name:            "No patterns - should allow all",
-			includePatterns: []string{},
-			excludePatterns: []string{},
-			url:             "https://example.com/page",
-			expected:        true,
-		},
-		{
-			name:            "Include pattern match",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*"},
-			excludePatterns: []string{},
-			url:             "https://example.com/page",
-			expected:        true,
-		},
-		{
-			name:            "Include pattern no match",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*"},
-			excludePatterns: []string{},
-			url:             "https://other.com/page",
-			expected:        false,
-		},
-		{
-			name:            "Multiple include patterns - first matches",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*", "^https?://[^/]*blog\\.com/.*"},
-			excludePatterns: []string{},
-			url:             "https://example.com/page",
-			expected:        true,
-		},
-		{
-			name:            "Multiple include patterns - second matches",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*", "^https?://[^/]*blog\\.com/.*"},
-			excludePatterns: []string{},
-			url:             "https://blog.com/post",
-			expected:        true,
-		},
-		{
-			name:            "Multiple include patterns - none match",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*", "^https?://[^/]*blog\\.com/.*"},
-			excludePatterns: []string{},
-			url:             "https://other.com/page",
-			expected:        false,
-		},
-		{
-			name:            "Exclude pattern match",
-			includePatterns: []string{},
-			excludePatterns: []string{"\\.pdf$"},
-			url:             "https://example.com/file.pdf",
-			expected:        false,
-		},
-		{
-			name:            "Exclude pattern no match",
-			includePatterns: []string{},
-			excludePatterns: []string{"\\.pdf$"},
-			url:             "https://example.com/page.html",
-			expected:        true,
-		},
-		{
-			name:            "Include match but exclude match - exclude wins",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*"},
-			excludePatterns: []string{"\\.pdf$"},
-			url:             "https://example.com/file.pdf",
-			expected:        false,
-		},
-		{
-			name:            "Include match and exclude no match - include wins",
-			includePatterns: []string{"^https?://[^/]*example\\.com/.*"},
-			excludePatterns: []string{"\\.pdf$"},
-			url:             "https://example.com/page.html",
-			expected:        true,
-		},
-		{
-			name:            "Complex include pattern with path",
-			includePatterns: []string{"^https?://[^/]*example\\.com/blog/.*"},
-			excludePatterns: []string{},
-			url:             "https://example.com/blog/post1",
-			expected:        true,
-		},
-		{
-			name:            "Complex include pattern with path - no match",
-			includePatterns: []string{"^https?://[^/]*example\\.com/blog/.*"},
-			excludePatterns: []string{},
-			url:             "https://example.com/news/post1",
-			expected:        false,
-		},
-		{
-			name:            "Multiple exclude patterns",
-			includePatterns: []string{},
-			excludePatterns: []string{"\\.pdf$", "/admin/.*", ".*\\?print=1"},
-			url:             "https://example.com/admin/panel",
-			expected:        false,
-		},
-		{
-			name:            "Admin exclude pattern",
-			includePatterns: []string{},
-			excludePatterns: []string{"/admin/.*"},
-			url:             "https://example.com/admin/panel",
-			expected:        false,
-		},
-		{
-			name:            "Print parameter exclude",
-			includePatterns: []string{},
-			excludePatterns: []string{".*\\?print=1"},
-			url:             "https://example.com/page?print=1",
-			expected:        false,
-		},
+		{"https://example.com/news", true},
+		{"https://example.com:443/news", true},
+		{"http://example.com/news", false},
+		{"https://example.com.evil.test/news", false},
+		{"https://example.com/ika/page", false},
+		{"https://example.com/%69ka/page", true},
+		{"https://example.com@evil.test/news", false},
+		{"javascript:alert(1)", false},
 	}
-
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			crawler := &DefaultCrawler{
-				config: &config.CrawlConfig{
-					IncludePatterns:     tt.includePatterns,
-					ExcludePatterns:     tt.excludePatterns,
-					FollowExternalHosts: true, // Allow all hosts for legacy tests
-				},
-				allowedHosts:    []string{}, // Empty list but external hosts allowed
-				includePatterns: mustCompilePatterns(t, tt.includePatterns),
-				excludePatterns: mustCompilePatterns(t, tt.excludePatterns),
-			}
-
-			result := crawler.shouldCrawlURL(tt.url)
-			if result != tt.expected {
-				t.Errorf("shouldCrawlURL() = %v, expected %v for URL %s", result, tt.expected, tt.url)
-			}
-		})
+		if got := policy.allows(tt.url); got != tt.want {
+			t.Errorf("allows(%q) = %v, want %v", tt.url, got, tt.want)
+		}
 	}
 }
 
-func TestIsAllowedHost(t *testing.T) {
-	tests := []struct {
-		name           string
-		seedURLs       []string
-		followExternal bool
-		targetURL      string
-		expected       bool
-	}{
-		{
-			name:           "Same host allowed - exact match",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "https://example.com/page",
-			expected:       true,
-		},
-		{
-			name:           "Different host blocked",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "https://other.com/page",
-			expected:       false,
-		},
-		{
-			name:           "Different scheme blocked",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "http://example.com/page",
-			expected:       false,
-		},
-		{
-			name:           "Different port blocked",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "https://example.com:8080/page",
-			expected:       false,
-		},
-		{
-			name:           "Subdomain blocked",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "https://www.example.com/page",
-			expected:       false,
-		},
-		{
-			name:           "Multiple seed URLs - first host matches",
-			seedURLs:       []string{"https://example.com", "https://blog.com"},
-			followExternal: false,
-			targetURL:      "https://example.com/page",
-			expected:       true,
-		},
-		{
-			name:           "Multiple seed URLs - second host matches",
-			seedURLs:       []string{"https://example.com", "https://blog.com"},
-			followExternal: false,
-			targetURL:      "https://blog.com/post",
-			expected:       true,
-		},
-		{
-			name:           "Multiple seed URLs - no match",
-			seedURLs:       []string{"https://example.com", "https://blog.com"},
-			followExternal: false,
-			targetURL:      "https://other.com/page",
-			expected:       false,
-		},
-		{
-			name:           "External hosts allowed - different host",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: true,
-			targetURL:      "https://other.com/page",
-			expected:       true,
-		},
-		{
-			name:           "External hosts allowed - same host",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: true,
-			targetURL:      "https://example.com/page",
-			expected:       true,
-		},
-		{
-			name:           "Invalid URL",
-			seedURLs:       []string{"https://example.com"},
-			followExternal: false,
-			targetURL:      "invalid-url",
-			expected:       false,
-		},
-		{
-			name:           "Empty seed URLs - external disabled",
-			seedURLs:       []string{},
-			followExternal: false,
-			targetURL:      "https://example.com/page",
-			expected:       false,
-		},
-		{
-			name:           "Empty seed URLs - external enabled",
-			seedURLs:       []string{},
-			followExternal: true,
-			targetURL:      "https://example.com/page",
-			expected:       true,
-		},
+func TestURLPolicyIncludeRequiresFullStringMatch(t *testing.T) {
+	policy, err := newURLPolicy(
+		[]string{"https://"},
+		[]string{`^https://good\.example/$|https://extra\.example/search`},
+		nil,
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://good.example/", true},
+		{"https://good.example/path", false},
+		{"https://extra.example/search", true},
+		{"https://extra.example/search/more", false},
+	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a crawler with the test configuration
-			config := &config.CrawlConfig{
-				SeedURLs:            tt.seedURLs,
-				FollowExternalHosts: tt.followExternal,
-			}
-
-			// Extract allowed hosts like NewCrawler does
-			allowedHosts := make([]string, 0, len(config.SeedURLs))
-			for _, seedURL := range config.SeedURLs {
-				if parsedURL, err := url.Parse(seedURL); err == nil {
-					host := parsedURL.Scheme + "://" + parsedURL.Host
-					// Avoid duplicates
-					found := false
-					for _, existing := range allowedHosts {
-						if existing == host {
-							found = true
-							break
-						}
-					}
-					if !found {
-						allowedHosts = append(allowedHosts, host)
-					}
-				}
-			}
-
-			crawler := &DefaultCrawler{
-				config:       config,
-				allowedHosts: allowedHosts,
-			}
-
-			result := crawler.isAllowedHost(tt.targetURL)
-			if result != tt.expected {
-				t.Errorf("isAllowedHost() = %v, expected %v for URL %s with seeds %v", result, tt.expected, tt.targetURL, tt.seedURLs)
-			}
-		})
+		if got := policy.allows(tt.url); got != tt.want {
+			t.Errorf("allows(%q) = %v, want %v", tt.url, got, tt.want)
+		}
 	}
 }
 
-func TestShouldCrawlURLWithHostFiltering(t *testing.T) {
-	tests := []struct {
-		name            string
-		seedURLs        []string
-		followExternal  bool
-		includePatterns []string
-		excludePatterns []string
-		targetURL       string
-		expected        bool
-	}{
-		{
-			name:            "Same host - no patterns",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  false,
-			includePatterns: []string{},
-			excludePatterns: []string{},
-			targetURL:       "https://example.com/page",
-			expected:        true,
-		},
-		{
-			name:            "External host blocked - no patterns",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  false,
-			includePatterns: []string{},
-			excludePatterns: []string{},
-			targetURL:       "https://other.com/page",
-			expected:        false,
-		},
-		{
-			name:            "External host allowed - no patterns",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  true,
-			includePatterns: []string{},
-			excludePatterns: []string{},
-			targetURL:       "https://other.com/page",
-			expected:        true,
-		},
-		{
-			name:            "Same host - matches include pattern",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  false,
-			includePatterns: []string{".*example\\.com.*"},
-			excludePatterns: []string{},
-			targetURL:       "https://example.com/page",
-			expected:        true,
-		},
-		{
-			name:            "External host - matches include pattern but blocked by host filter",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  false,
-			includePatterns: []string{".*other\\.com.*"},
-			excludePatterns: []string{},
-			targetURL:       "https://other.com/page",
-			expected:        false, // Host filter takes precedence
-		},
-		{
-			name:            "Same host - blocked by exclude pattern",
-			seedURLs:        []string{"https://example.com"},
-			followExternal:  false,
-			includePatterns: []string{},
-			excludePatterns: []string{"\\.pdf$"},
-			targetURL:       "https://example.com/file.pdf",
-			expected:        false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a crawler with the test configuration
-			config := &config.CrawlConfig{
-				SeedURLs:            tt.seedURLs,
-				FollowExternalHosts: tt.followExternal,
-				IncludePatterns:     tt.includePatterns,
-				ExcludePatterns:     tt.excludePatterns,
-			}
-
-			// Extract allowed hosts like NewCrawler does
-			allowedHosts := make([]string, 0, len(config.SeedURLs))
-			for _, seedURL := range config.SeedURLs {
-				if parsedURL, err := url.Parse(seedURL); err == nil {
-					host := parsedURL.Scheme + "://" + parsedURL.Host
-					// Avoid duplicates
-					found := false
-					for _, existing := range allowedHosts {
-						if existing == host {
-							found = true
-							break
-						}
-					}
-					if !found {
-						allowedHosts = append(allowedHosts, host)
-					}
-				}
-			}
-
-			crawler := &DefaultCrawler{
-				config:          config,
-				allowedHosts:    allowedHosts,
-				includePatterns: mustCompilePatterns(t, config.IncludePatterns),
-				excludePatterns: mustCompilePatterns(t, config.ExcludePatterns),
-			}
-
-			result := crawler.shouldCrawlURL(tt.targetURL)
-			if result != tt.expected {
-				t.Errorf("shouldCrawlURL() = %v, expected %v for URL %s with config %+v", result, tt.expected, tt.targetURL, config)
-			}
-		})
+func TestURLPolicyRejectsLegacyRelativeInclude(t *testing.T) {
+	if _, err := newURLPolicy(nil, []string{`/products/`}, nil, false); err == nil {
+		t.Fatal("relative include pattern was accepted")
 	}
 }
 
-func TestIsAllowedHostWithPrefixMatching(t *testing.T) {
-	tests := []struct {
-		name        string
-		seedURLs    []string
-		targetURL   string
-		expected    bool
-		description string
-	}{
-		{
-			name:        "Exact match with seed URL",
-			seedURLs:    []string{"https://example.com/abc/def"},
-			targetURL:   "https://example.com/abc/def",
-			expected:    true,
-			description: "URL exactly matches seed URL",
-		},
-		{
-			name:        "Prefix match with trailing path",
-			seedURLs:    []string{"https://example.com/abc/def"},
-			targetURL:   "https://example.com/abc/def/ghi",
-			expected:    true,
-			description: "URL starts with seed URL prefix followed by path",
-		},
-		{
-			name:        "Prefix match without trailing slash",
-			seedURLs:    []string{"https://example.com/abc"},
-			targetURL:   "https://example.com/abc/def",
-			expected:    true,
-			description: "URL starts with seed URL prefix",
-		},
-		{
-			name:        "Same host but different path prefix",
-			seedURLs:    []string{"https://example.com/abc/def"},
-			targetURL:   "https://example.com/xyz/def",
-			expected:    true,
-			description: "Same host allows all paths with current implementation",
-		},
-		{
-			name:        "Same host different path allowed",
-			seedURLs:    []string{"https://example.com/abc"},
-			targetURL:   "https://example.com/abcdef",
-			expected:    true,
-			description: "Same host allows all paths with current implementation",
-		},
-		{
-			name:        "Root path allows all subpaths",
-			seedURLs:    []string{"https://example.com"},
-			targetURL:   "https://example.com/any/path",
-			expected:    true,
-			description: "Root path seed URL allows any subpath",
-		},
-		{
-			name:        "Multiple seeds - one matches",
-			seedURLs:    []string{"https://example.com/blog", "https://other.com/news"},
-			targetURL:   "https://example.com/blog/post1",
-			expected:    true,
-			description: "URL matches one of multiple seed URL prefixes",
-		},
-		{
-			name:        "Different scheme should not match",
-			seedURLs:    []string{"https://example.com/abc"},
-			targetURL:   "http://example.com/abc/def",
-			expected:    false,
-			description: "Different scheme should not match even with same host and path",
-		},
-		{
-			name:        "Invalid URL scheme filtered out",
-			seedURLs:    []string{"https://example.com"},
-			targetURL:   "tel:+1234567890",
-			expected:    false,
-			description: "Invalid URL schemes should be filtered out by isAllowedScheme",
-		},
+func TestURLPolicyFollowExternalStillHonorsExclude(t *testing.T) {
+	policy, err := newURLPolicy(nil, nil, []string{`/private/`}, true)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create configuration similar to NewCrawler
-			config := &config.CrawlConfig{
-				SeedURLs:            tt.seedURLs,
-				FollowExternalHosts: false, // Test same-host restriction
-				AllowedSchemes:      []string{"https://", "http://"},
-			}
-
-			// Extract allowed hosts like NewCrawler does (scheme://host format)
-			allowedHosts := make([]string, 0, len(config.SeedURLs))
-			for _, seedURL := range config.SeedURLs {
-				if parsedURL, err := url.Parse(seedURL); err == nil {
-					host := parsedURL.Scheme + "://" + parsedURL.Host
-					// Avoid duplicates
-					found := false
-					for _, existing := range allowedHosts {
-						if existing == host {
-							found = true
-							break
-						}
-					}
-					if !found {
-						allowedHosts = append(allowedHosts, host)
-					}
-				}
-			}
-
-			crawler := &DefaultCrawler{
-				config:       config,
-				allowedHosts: allowedHosts,
-			}
-
-			result := crawler.isAllowedHost(tt.targetURL)
-			if result != tt.expected {
-				t.Errorf("%s: isAllowedHost(%q) = %v, expected %v. %s",
-					tt.name, tt.targetURL, result, tt.expected, tt.description)
-			}
-		})
+	if !policy.allows("https://other.example/public/page") {
+		t.Fatal("follow_external_hosts did not allow an external URL")
+	}
+	if policy.allows("https://other.example/private/page") {
+		t.Fatal("exclude did not override follow_external_hosts")
 	}
 }
 
-func TestConfigAllowedSchemes(t *testing.T) {
-	tests := []struct {
-		name           string
-		allowedSchemes []string
-		targetURL      string
-		expected       bool
-		description    string
-	}{
-		{
-			name:           "HTTPS allowed by default",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "https://example.com/page",
-			expected:       true,
-			description:    "HTTPS URLs should be allowed with default scheme configuration",
-		},
-		{
-			name:           "HTTP allowed by default",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "http://example.com/page",
-			expected:       true,
-			description:    "HTTP URLs should be allowed with default scheme configuration",
-		},
-		{
-			name:           "FTP blocked by default",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "ftp://ftp.example.com/file.txt",
-			expected:       false,
-			description:    "FTP URLs should be blocked with default scheme configuration",
-		},
-		{
-			name:           "Custom schemes - FTP allowed",
-			allowedSchemes: []string{"https://", "http://", "ftp://"},
-			targetURL:      "ftp://ftp.example.com/file.txt",
-			expected:       true,
-			description:    "FTP URLs should be allowed when explicitly configured",
-		},
-		{
-			name:           "Tel scheme blocked",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "tel:+1234567890",
-			expected:       false,
-			description:    "Tel URLs should always be blocked",
-		},
-		{
-			name:           "Mailto scheme blocked",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "mailto:test@example.com",
-			expected:       false,
-			description:    "Mailto URLs should always be blocked",
-		},
-		{
-			name:           "JavaScript scheme blocked",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "javascript:alert('test')",
-			expected:       false,
-			description:    "JavaScript URLs should always be blocked",
-		},
-		{
-			name:           "Chrome extension scheme blocked",
-			allowedSchemes: []string{"https://", "http://"},
-			targetURL:      "chrome-extension://abc123/popup.html",
-			expected:       false,
-			description:    "Chrome extension URLs should always be blocked",
-		},
-		{
-			name:           "Empty scheme list defaults to HTTP/HTTPS",
-			allowedSchemes: []string{}, // Should fall back to defaults
-			targetURL:      "https://example.com/page",
-			expected:       true,
-			description:    "Empty scheme list should default to allowing HTTPS",
-		},
-		{
-			name:           "HTTPS only configuration",
-			allowedSchemes: []string{"https://"},
-			targetURL:      "http://example.com/page",
-			expected:       false,
-			description:    "HTTP should be blocked when only HTTPS is allowed",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create configuration with custom allowed schemes
-			config := &config.CrawlConfig{
-				SeedURLs:            []string{"https://example.com"},
-				FollowExternalHosts: true, // Allow external to focus on scheme testing
-				AllowedSchemes:      tt.allowedSchemes,
-			}
-
-			allowedHosts := []string{"https://example.com"}
-
-			crawler := &DefaultCrawler{
-				config:       config,
-				allowedHosts: allowedHosts,
-			}
-
-			result := crawler.isAllowedScheme(tt.targetURL)
-			if result != tt.expected {
-				t.Errorf("%s: isAllowedScheme(%q) with schemes %v = %v, expected %v. %s",
-					tt.name, tt.targetURL, tt.allowedSchemes, result, tt.expected, tt.description)
-			}
-		})
+func TestCompilePatternsRejectsInvalidRegexp(t *testing.T) {
+	if _, err := compilePatterns([]string{"["}); err == nil {
+		t.Fatal("invalid regexp was accepted")
 	}
 }

--- a/internal/crawler/url_policy.go
+++ b/internal/crawler/url_policy.go
@@ -1,0 +1,176 @@
+package crawler
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// urlPolicy is the crawler's single URL authorization decision. Persisted
+// depth-zero origins and explicit include expressions add allowed ranges;
+// excludes always win.
+type urlPolicy struct {
+	allowedSchemes  map[string]struct{}
+	implicitOrigins map[string]struct{}
+	includes        []*regexp.Regexp
+	excludes        []*regexp.Regexp
+	allowAll        bool
+}
+
+func newURLPolicy(allowedSchemes, includes, excludes []string, allowAll bool) (*urlPolicy, error) {
+	schemes := make(map[string]struct{})
+	if len(allowedSchemes) == 0 {
+		allowedSchemes = []string{"https://", "http://"}
+	}
+	for _, value := range allowedSchemes {
+		scheme := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(value), "://"))
+		if scheme != "" {
+			schemes[scheme] = struct{}{}
+		}
+	}
+
+	includePatterns := make([]*regexp.Regexp, 0, len(includes))
+	for _, pattern := range includes {
+		if !strings.Contains(pattern, "://") {
+			return nil, fmt.Errorf("include pattern %q is relative; rewrite it as an absolute full-URL pattern", pattern)
+		}
+		compiled, err := regexp.Compile(`\A(?:` + pattern + `)\z`)
+		if err != nil {
+			return nil, fmt.Errorf("include pattern %q: %w", pattern, err)
+		}
+		includePatterns = append(includePatterns, compiled)
+	}
+
+	excludePatterns, err := compilePatterns(excludes)
+	if err != nil {
+		return nil, fmt.Errorf("exclude pattern: %w", err)
+	}
+
+	return &urlPolicy{
+		allowedSchemes:  schemes,
+		implicitOrigins: make(map[string]struct{}),
+		includes:        includePatterns,
+		excludes:        excludePatterns,
+		allowAll:        allowAll,
+	}, nil
+}
+
+// compilePatterns compiles ordinary (substring-match) regular expressions.
+func compilePatterns(patterns []string) ([]*regexp.Regexp, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("pattern %q: %w", pattern, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return compiled, nil
+}
+
+func (p *urlPolicy) setImplicitOrigins(urls []string) error {
+	origins, err := p.origins(urls)
+	if err != nil {
+		return err
+	}
+	p.implicitOrigins = origins
+	return nil
+}
+
+func (p *urlPolicy) validateExplicitURLs(urls []string) error {
+	for _, raw := range urls {
+		if _, _, err := p.parse(raw); err != nil {
+			return fmt.Errorf("invalid seed URL %q: %w", raw, err)
+		}
+	}
+	return nil
+}
+
+func (p *urlPolicy) allows(raw string) bool {
+	_, origin, err := p.parse(raw)
+	if err != nil {
+		return false
+	}
+
+	allowed := p.allowAll
+	if !allowed {
+		_, allowed = p.implicitOrigins[origin]
+	}
+	if !allowed {
+		for _, re := range p.includes {
+			if re.MatchString(raw) {
+				allowed = true
+				break
+			}
+		}
+	}
+	if !allowed {
+		return false
+	}
+
+	for _, re := range p.excludes {
+		if re.MatchString(raw) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *urlPolicy) origins(urls []string) (map[string]struct{}, error) {
+	origins := make(map[string]struct{}, len(urls))
+	for _, raw := range urls {
+		_, origin, err := p.parse(raw)
+		if err != nil {
+			return nil, err
+		}
+		origins[origin] = struct{}{}
+	}
+	return origins, nil
+}
+
+func (p *urlPolicy) parse(raw string) (*url.URL, string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, "", fmt.Errorf("malformed absolute URL: %w", err)
+	}
+	if !parsed.IsAbs() || parsed.Host == "" {
+		return nil, "", fmt.Errorf("URL must be absolute")
+	}
+	if parsed.User != nil {
+		return nil, "", fmt.Errorf("URL userinfo is not allowed")
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if _, ok := p.allowedSchemes[scheme]; !ok {
+		return nil, "", fmt.Errorf("unsupported URL scheme %q", parsed.Scheme)
+	}
+	origin, err := originKey(parsed)
+	if err != nil {
+		return nil, "", err
+	}
+	return parsed, origin, nil
+}
+
+func originKey(parsed *url.URL) (string, error) {
+	scheme := strings.ToLower(parsed.Scheme)
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return "", fmt.Errorf("URL host is empty")
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		}
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	}
+	return scheme + "://" + host, nil
+}

--- a/internal/storage/depth_test.go
+++ b/internal/storage/depth_test.go
@@ -237,6 +237,55 @@ func TestSeedTransactionFailsBeforeMutatingWhenOtherLegacyWorkExists(t *testing.
 	}
 }
 
+func TestDepthZeroURLsAndResumableRetry(t *testing.T) {
+	store := newTempStorage(t)
+	if err := store.AddSeeds([]string{"https://example.com/root"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddToQueue([]string{"https://other.example/error"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	item, err := store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim root: item=%+v err=%v", item, err)
+	}
+	if err := store.SavePageResult(item.ID, &crawler.PageData{URL: item.URL, HTTPHeaders: map[string]string{}, CrawledAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	item, err = store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim error row: item=%+v err=%v", item, err)
+	}
+	if err := store.SavePageError(item.ID, "network_error", "temporary"); err != nil {
+		t.Fatal(err)
+	}
+
+	roots, err := store.GetDepthZeroURLs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 || roots[0] != "https://example.com/root" {
+		t.Fatalf("roots = %v", roots)
+	}
+	hasWork, err := store.HasResumableWork()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasWork {
+		t.Fatal("retryable error was not resumable work")
+	}
+	if _, err := store.RequeueErrorPages(crawler.MaxRetryAttempts); err != nil {
+		t.Fatal(err)
+	}
+	item, err = store.GetNextFromQueue()
+	if err != nil || item == nil {
+		t.Fatalf("claim requeued error: item=%+v err=%v", item, err)
+	}
+	if item.Depth != 1 {
+		t.Fatalf("retry depth = %d, want 1", item.Depth)
+	}
+}
+
 func TestStaleProcessingCleanupPreservesDepthAndRetryCount(t *testing.T) {
 	store := newTempStorage(t)
 	const pageURL = "https://example.com/interrupted"

--- a/internal/storage/issue46_test.go
+++ b/internal/storage/issue46_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"database/sql"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -232,9 +233,12 @@ func mustSaveResult(t *testing.T, s *SQLiteStorage, id int) {
 func TestMigratePagesAddDiscovered(t *testing.T) {
 	dbFile := filepath.Join(t.TempDir(), "legacy.db")
 
-	// Build a legacy database by stripping 'discovered' from the current schema.
+	// Build a legacy database by stripping both the 'discovered' status and the
+	// later ALTER-added depth column from the current schema.
 	legacySchema := strings.Replace(schemaSQL, ", 'discovered'", "", 1)
-	if legacySchema == schemaSQL {
+	legacySchema = strings.Replace(legacySchema, "    depth INTEGER,\n", "", 1)
+	legacySchema = strings.Replace(legacySchema, "CREATE INDEX IF NOT EXISTS idx_pages_status_depth_added_id ON pages(status, depth, added_at, id);\n", "", 1)
+	if legacySchema == schemaSQL || strings.Contains(legacySchema, "depth INTEGER") {
 		t.Fatal("failed to derive legacy schema; marker not found")
 	}
 
@@ -271,10 +275,20 @@ func TestMigratePagesAddDiscovered(t *testing.T) {
 	if err := legacy.InitSchema(); err != nil {
 		t.Fatalf("InitSchema (migration) failed: %v", err)
 	}
+	if err := legacy.InitSchema(); err != nil {
+		t.Fatalf("InitSchema (idempotent migration) failed: %v", err)
+	}
 
 	// Existing data preserved.
 	if got := mustStatus(t, legacy, "https://example.com/legacy"); got != "completed" {
 		t.Errorf("legacy row status = %q, want completed", got)
+	}
+	var migratedDepth sql.NullInt64
+	if err := legacy.db.QueryRow("SELECT depth FROM pages WHERE url = 'https://example.com/legacy'").Scan(&migratedDepth); err != nil {
+		t.Fatalf("depth column missing after migration: %v", err)
+	}
+	if migratedDepth.Valid {
+		t.Fatalf("legacy depth = %v, want NULL", migratedDepth)
 	}
 	// 'discovered' now accepted.
 	if _, err := legacy.db.Exec("INSERT INTO pages (url, status) VALUES ('https://example.com/now', 'discovered')"); err != nil {

--- a/internal/storage/retry_test.go
+++ b/internal/storage/retry_test.go
@@ -37,14 +37,6 @@ func TestRetryEligibilityMatchesWrittenErrorTypes(t *testing.T) {
 	}
 
 	// Transport and selected HTTP failures are eligible.
-	items, err := store.GetRetryablePages(3)
-	if err != nil {
-		t.Fatalf("GetRetryablePages: %v", err)
-	}
-	if len(items) != 2 {
-		t.Errorf("retryable = %+v, want network and transient HTTP pages", items)
-	}
-
 	requeued, err := store.RequeueErrorPages(3)
 	if err != nil {
 		t.Fatalf("RequeueErrorPages: %v", err)

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -571,10 +571,23 @@ func (s *SQLiteStorage) HasQueuedItems() (bool, error) {
 	return count > 0, nil
 }
 
-func (s *SQLiteStorage) HasAnyPages() (bool, error) {
+// HasResumableWork reports whether a seedless run has queued work or a
+// retryable failure that the post-drain retry pass can recover.
+func (s *SQLiteStorage) HasResumableWork() (bool, error) {
 	var found bool
-	if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM pages)`).Scan(&found); err != nil {
-		return false, fmt.Errorf("failed to check pages: %w", err)
+	err := s.db.QueryRow(`
+		SELECT EXISTS(
+			SELECT 1 FROM pages
+			WHERE status IN ('pending', 'processing')
+			   OR (
+				status = 'error'
+				AND retry_count < ?
+				AND last_error_type IN `+retryableErrorTypes+`
+			)
+		)
+	`, crawler.MaxRetryAttempts).Scan(&found)
+	if err != nil {
+		return false, fmt.Errorf("failed to check resumable work: %w", err)
 	}
 	return found, nil
 }
@@ -623,6 +636,29 @@ func validateDepthTracking(q depthQueryer, seedURLs []string) error {
 	return fmt.Errorf("database contains unfinished URL without discovery depth: %s; use a fresh database or explicitly supply that URL as a seed", url)
 }
 
+// GetDepthZeroURLs returns the persisted authorization roots. Terminal seeds
+// remain roots because a reused database accumulates explicit depth-zero rows.
+func (s *SQLiteStorage) GetDepthZeroURLs() ([]string, error) {
+	rows, err := s.db.Query(`SELECT url FROM pages WHERE depth = 0 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load depth-zero URLs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var urls []string
+	for rows.Next() {
+		var url string
+		if err := rows.Scan(&url); err != nil {
+			return nil, fmt.Errorf("failed to scan depth-zero URL: %w", err)
+		}
+		urls = append(urls, url)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate depth-zero URLs: %w", err)
+	}
+	return urls, nil
+}
+
 // retryableErrorTypes lists the last_error_type values eligible for retry.
 // These MUST match the strings the crawler writes for retryable failures:
 // 'network_error' covers transient transport failures and 'http_transient'
@@ -632,37 +668,6 @@ func validateDepthTracking(q depthQueryer, seedURLs []string) error {
 // and 'response_too_large' (deterministic — the page will exceed the limit
 // again).
 const retryableErrorTypes = `('network_error', 'http_transient')`
-
-// GetRetryablePages returns pages with error status that can be retried.
-func (s *SQLiteStorage) GetRetryablePages(maxRetries int) ([]crawler.URLItem, error) {
-	rows, err := s.db.Query(`
-		SELECT id, url, retry_count, last_error_type
-		FROM pages
-		WHERE status = 'error'
-		  AND retry_count < ?
-		  AND last_error_type IN `+retryableErrorTypes+`
-		ORDER BY retry_count ASC, added_at ASC
-	`, maxRetries)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get retryable pages: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var items []crawler.URLItem
-	for rows.Next() {
-		var item crawler.URLItem
-		var errorType string
-		var retryCount int
-		if err := rows.Scan(&item.ID, &item.URL, &retryCount, &errorType); err != nil {
-			return nil, fmt.Errorf("failed to scan retryable page: %w", err)
-		}
-		items = append(items, item)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("failed to iterate retryable pages: %w", err)
-	}
-	return items, nil
-}
 
 // RequeueErrorPages moves error status pages back to pending for retry
 func (s *SQLiteStorage) RequeueErrorPages(maxRetries int) (int, error) {

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -9,7 +9,7 @@ user_agent: "LinkTadoru/1.0"       # User-Agent header (version will be dynamica
 ignore_robots_txt: false    # Whether to ignore robots.txt rules (default: respect robots.txt)
 follow_external_hosts: false # Whether to crawl external hosts (default: same-host only for safety)
 limit: 0                    # Stop after N pages (0 = unlimited)
-max_depth: 0                # 0 = unlimited; N > 0 includes discovery depth N (fresh DB only for now)
+max_depth: 0                # 0 = unlimited; positive N includes first-discovery depth N
 max_response_size: 10485760 # Max response body size in bytes (default: 10 MiB); larger pages are recorded as errors
 
 # Database configuration
@@ -22,13 +22,17 @@ log_file: ""                # Path to log file (empty = no file logging)
 log_max_size: 100           # Max log file size in MB before rotation (default: 100)
 log_max_backups: 5          # Number of rotated log files to keep (default: 5)
 
-# URL filtering patterns
-include_patterns: []         # Regex patterns for URLs to include (empty = include all)
-exclude_patterns:           # Regex patterns for URLs to exclude
-  - "\\.pdf$"              # Exclude PDF files
-  - "/admin/.*"            # Exclude admin pages
-  - "\\.zip$"              # Exclude ZIP files
-  - "\\.exe$"              # Exclude executable files
+# URL policy patterns (Go regexp/RE2; slash characters need no escaping)
+# Seeds implicitly allow their exact origins. Absolute full-URL includes add
+# trusted ranges; excludes subtract and always win. Prefer single-quoted YAML.
+include_patterns: []
+# include_patterns:
+#   - '^https://search\.example/search(?:/.*)?(?:\?.*)?$'
+exclude_patterns:
+  - '\.pdf$'               # Exclude PDF files
+  - '/admin/'               # Exclude admin paths
+  - '\.zip$'               # Exclude ZIP files
+  - '\.exe$'               # Exclude executable files
 
 # Authentication configuration
 # Note: configure AT MOST ONE method — filling in credentials for more than one
@@ -92,11 +96,11 @@ headers:
 # Site-specific crawling with custom user agent:
 # user_agent: "MyBot/1.0 (https://example.com/bot)"
 # include_patterns:
-#   - "^https://target-site\\.com/.*"
+#   - '^https://target-site\.com/.*$'
 # exclude_patterns:
-#   - "/login"
-#   - "/admin"
-#   - "\\.pdf$"
+#   - '/login'
+#   - '/admin'
+#   - '\.pdf$'
 
 # Cross-site crawling (follow external links):
 # follow_external_hosts: true


### PR DESCRIPTION
## Summary

- replace allowedHosts, link-type gating, and duplicated filters with one URL policy shared by queued URLs, discovered links, redirects, and retries
- treat persisted depth-zero seed origins as implicit includes, with explicit include regexes adding ranges and excludes always winning
- restore bounded and seedless resume from persisted queue state while keeping credentials limited to seeds supplied for the current invocation
- evaluate policy before robots.txt or any other network request, and strip credentials monotonically after a redirect leaves its original origin
- document Go regular-expression syntax, examples, compatibility warnings, and the absence of URL percent-decoding

## Dependency

PR #80 is merged. This PR is now based directly on main and contains only the policy/resume delta on top of persisted discovery depth.

## Deliberate limits

- no BFS barrier, layer scheduler, MIN-depth propagation, is_seed column, crawl-mode metadata, URL-family scheduler, or URL canonicalization subsystem
- persisted queue rows remain authoritative; max_depth controls new admissions
- discovery depth remains first admission rather than shortest path

## Testing

- gofmt -l .
- git diff --check
- go vet ./...
- go build ./...
- go test ./... -count=1 -race

Closes #79