### PR TITLE
Prepare the next compatibility release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,7 @@ Note: direct pushes to `main` do not trigger CI. Run it manually when needed: `g
 - Test execution (final confirmation)
 - Multi-platform builds (Linux amd64/arm64, macOS arm64, Windows amd64)
 - Automatic GitHub Release creation
-- Release notes generation
+- Release notes generation from the matching version section in `CHANGELOG.md`
 
 ## Local Testing (act)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,48 +97,60 @@ jobs:
     - name: Generate release notes
       id: release_notes
       run: |
-        # Get commits since last tag
-        if git describe --tags --abbrev=0 HEAD~1 >/dev/null 2>&1; then
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1)
-          COMMITS=$(git log --pretty=format:"- %s (%h)" $PREVIOUS_TAG..HEAD)
-        else
-          COMMITS=$(git log --pretty=format:"- %s (%h)" --max-count=10)
-        fi
-        
-        cat > release_notes.md << EOF
-        ## Changes in ${{ steps.version.outputs.tag }}
-        
-        $COMMITS
-        
+        VERSION="${{ steps.version.outputs.version }}"
+        awk -v heading="## [$VERSION]" '
+          $0 == heading || index($0, heading " - ") == 1 {
+            found = 1
+            next
+          }
+          found && /^## \[/ { exit }
+          found {
+            print
+            if ($0 !~ /^[[:space:]]*$/) content = 1
+          }
+          END {
+            if (!found || !content) {
+              print "CHANGELOG.md has no non-empty section for " heading > "/dev/stderr"
+              exit 1
+            }
+          }
+        ' CHANGELOG.md > changelog_release_notes.md
+
+        {
+          echo "## Changes in ${{ steps.version.outputs.tag }}"
+          echo
+          cat changelog_release_notes.md
+          cat <<'EOF'
         ## Downloads
-        
+
         Choose the appropriate binary for your platform:
-        
+
         - **Linux x86_64**: \`linktadoru-linux-amd64\`
         - **Linux ARM64**: \`linktadoru-linux-arm64\`
         - **macOS ARM64**: \`linktadoru-darwin-arm64\`
         - **Windows x86_64**: \`linktadoru-windows-amd64.exe\`
-        
+
         ## Installation
-        
+
         ### Linux / macOS
         \`\`\`bash
         # Download and make executable
         chmod +x linktadoru-linux-amd64
         ./linktadoru-linux-amd64 --version
         \`\`\`
-        
+
         ### Windows
         \`\`\`powershell
         # Test the binary
         .\\linktadoru-windows-amd64.exe --version
         \`\`\`
-        
+
         ### Using Go
         \`\`\`bash
         go install github.com/masahif/linktadoru/cmd/crawler@${{ steps.version.outputs.tag }}
         \`\`\`
         EOF
+        } > release_notes.md
 
     - name: Create Release
       uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
       run: |
         VERSION="${{ steps.version.outputs.version }}"
         awk -v heading="## [$VERSION]" '
+          { sub(/\r$/, "") }
           $0 == heading || index($0, heading " - ") == 1 {
             found = 1
             next
@@ -125,30 +126,30 @@ jobs:
 
         Choose the appropriate binary for your platform:
 
-        - **Linux x86_64**: \`linktadoru-linux-amd64\`
-        - **Linux ARM64**: \`linktadoru-linux-arm64\`
-        - **macOS ARM64**: \`linktadoru-darwin-arm64\`
-        - **Windows x86_64**: \`linktadoru-windows-amd64.exe\`
+        - **Linux x86_64**: `linktadoru-linux-amd64`
+        - **Linux ARM64**: `linktadoru-linux-arm64`
+        - **macOS ARM64**: `linktadoru-darwin-arm64`
+        - **Windows x86_64**: `linktadoru-windows-amd64.exe`
 
         ## Installation
 
         ### Linux / macOS
-        \`\`\`bash
+        ```bash
         # Download and make executable
         chmod +x linktadoru-linux-amd64
         ./linktadoru-linux-amd64 --version
-        \`\`\`
+        ```
 
         ### Windows
-        \`\`\`powershell
+        ```powershell
         # Test the binary
-        .\\linktadoru-windows-amd64.exe --version
-        \`\`\`
+        .\linktadoru-windows-amd64.exe --version
+        ```
 
         ### Using Go
-        \`\`\`bash
+        ```bash
         go install github.com/masahif/linktadoru/cmd/crawler@${{ steps.version.outputs.tag }}
-        \`\`\`
+        ```
         EOF
         } > release_notes.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,37 +6,94 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Compatibility and upgrade notes
+- **URL include semantics changed from filtering to authorization.** Persisted
+  depth-0 seed origins are always allowed; `include_patterns` now add absolute
+  full-URL ranges, and `exclude_patterns` subtract from the combined set.
+  Relative includes such as `/products/` are rejected at startup. During
+  discovered-link admission, existing absolute includes for non-seed origins
+  were previously inert behind the seed-host check; they now actively authorize
+  those ranges.
+- **`follow_external_hosts: true` now performs external fetches.** In v0.9.2,
+  the parent-host link gate left discovered external URLs graph-only even when
+  this option was enabled. It now permits crawling every URL with an allowed
+  scheme; `include_patterns` do not narrow this allow-all mode, while
+  `exclude_patterns` still apply. Review existing `true` configurations before
+  upgrading because their network reach can expand substantially, including to
+  private or link-local destinations linked by a crawled page.
+- **Bounded crawl depth is first-admission depth, not shortest-path BFS depth.**
+  Seeds are depth 0 and a newly queued child is `parent depth + 1`. All depths
+  use the asynchronous queue without a layer barrier. For `max_depth >= 2`, a
+  URL first admitted through a longer path can prevent descendants from being
+  fetched even if a shorter path is discovered later; response timing can
+  therefore affect the fetched set.
+- **Existing databases receive a nullable `pages.depth` column.** A run stops
+  before network access when unfinished legacy rows have unknown depth. Supply
+  those URLs explicitly as seeds, or use a fresh database. Changing seeds or
+  `max_depth` in a reused database does not retroactively recompute the depth of
+  other admitted or terminal rows; use a fresh database for independently
+  comparable snapshots.
+- **Explicit seeds now mean an explicit refresh.** Re-supplying an existing URL
+  queues it at depth 0, resets its retry budget, and clears its prior page/error
+  observation. Normal duplicate discovery still does not re-fetch terminal
+  rows. Command-line URL arguments and `--seed-file` also take precedence over
+  `seed_urls` loaded from configuration.
+- **Credential trust is invocation-specific.** Authentication and configured
+  custom headers are sent only to origins supplied as seeds in the current
+  invocation. A seedless resume with credentials configured fails closed and
+  asks for the seed list again.
+
 ### Added
-- `--seed-file` reads generated seed lists from a file or standard input.
-- SQLite now persists first-discovery depth. `max_depth: N` accepts any
-  non-negative N, prioritizes shallow queued work without a breadth-first
-  barrier, and supports depth-preserving resume.
+- `--seed-file` reads generated seed lists from a file or standard input (#67).
+- SQLite persists first-discovery depth. `max_depth: N` accepts any non-negative
+  N, prioritizes shallower queued work, and supports depth-preserving resume
+  (#68, #72).
 - URL authorization now uses one policy: exact persisted seed origins plus
   full-URL include regexes, minus exclude regexes. Includes can explicitly add
-  cross-origin ranges; relative legacy includes fail with a migration message.
+  cross-origin ranges; relative legacy includes fail with a migration message
+  (#79).
 
 ### Changed
-- Re-supplying an existing URL as a seed re-fetches it at depth 0 and clears
-  stale observations. Normal duplicate discovery still does not re-fetch a
-  queued or terminal URL.
 - Runs without explicit seeds now drain resumable database work, including
   bounded crawls, or exit successfully when no work remains.
-- Seed URLs containing userinfo are rejected; configure credentials separately.
-- Crawling stops before network access when a migrated database has unfinished
-  rows with unknown depth. Supply those URLs as seeds or use a fresh database.
-- Existing absolute non-seed-origin includes are now active cross-origin
-  authorization under OR semantics. Review these patterns before upgrading.
-- Credentials and configured custom headers are sent only to origins supplied
-  as seeds in the current invocation, and never reappear after an A-B-A
-  cross-origin redirect chain.
 - Outgoing external links are retained as graph-only `discovered` rows even
   when their URLs are not authorized for fetching.
 - In multi-seed crawls, links between persisted seed origins can now be fetched;
   the old parent-host `internal` link gate no longer narrows the shared policy.
+- Dependencies: `golang.org/x/net` 0.56.0 → 0.57.0 and
+  `modernc.org/sqlite` 1.38.2 → 1.56.0. GitHub Actions were updated to
+  `setup-go` v7, `upload-artifact` v7, and `softprops/action-gh-release` v3.
+
+### Security
+- The redirect protections released in v0.9.2 for
+  [GHSA-2692-7f24-52v6](https://github.com/masahif/linktadoru/security/advisories/GHSA-2692-7f24-52v6)
+  remain in force: every redirect hop is checked by the same URL policy before
+  contact, and cross-origin credentials and configured secret headers are
+  removed.
+- URL policy is evaluated before robots.txt lookup or any other network request;
+  a denied queued URL is stored as `skipped` without contacting its origin.
+- Credentials are never sent to origins authorized only by `include_patterns`,
+  and once an A-B-A redirect chain leaves its initial origin they do not
+  reappear when the chain returns to A.
+- Seed URLs containing userinfo are rejected; configure credentials separately.
 
 ### Fixed
 - HTTP 408, 429, 500, 502, 503, and 504 responses are now retained as errors
-  and retried after normal queue work, up to 3 total attempts per URL.
+  with their response status, headers, timing, and size, then retried after
+  normal queue work, up to 3 total attempts per URL. Permanent responses such
+  as 403, 404, and 410 remain completed observations and are not retried (#71).
+
+### Known limitations
+- Transient retries use the normal per-domain delay and robots.txt
+  `Crawl-delay`, but do not honor `Retry-After` or add a separate backoff.
+- A page that succeeds after a retry is marked `completed`, but its
+  `last_error_type`, error message, and retry count remain as attempt history;
+  use `pages.status` as the final outcome.
+- URL regex matching uses the stored absolute URL text and does not
+  percent-decode it. For example, `/ika/` does not match `/%69ka/`.
+- `follow_external_hosts: true` is an explicit allow-all compatibility mode;
+  there is no separate private-network, loopback, link-local, or cloud-metadata
+  address deny floor.
 
 ## [0.9.2] - 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **URL include semantics changed from filtering to authorization.** Persisted
   depth-0 seed origins are always allowed; `include_patterns` now add absolute
   full-URL ranges, and `exclude_patterns` subtract from the combined set.
-  Relative includes such as `/products/` are rejected at startup. During
+  Includes are matched against the entire absolute URL instead of as
+  substrings, so patterns that relied on partial matches must state their full
+  range. Relative includes such as `/products/` are rejected at startup. During
   discovered-link admission, existing absolute includes for non-seed origins
-  were previously inert behind the seed-host check; they now actively authorize
-  those ranges.
+  were previously inert behind the seed-host check; they now actively
+  authorize those ranges.
 - **`follow_external_hosts: true` now performs external fetches.** In v0.9.2,
   the parent-host link gate left discovered external URLs graph-only even when
   this option was enabled. It now permits crawling every URL with an allowed
@@ -38,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   observation. Normal duplicate discovery still does not re-fetch terminal
   rows. Command-line URL arguments and `--seed-file` also take precedence over
   `seed_urls` loaded from configuration.
+- **All explicit seeds are retained even when their count exceeds `--limit`.**
+  v0.9.2 discarded seeds beyond the current limit during initialization. They
+  are now queued before workers start, so seeds not reached in the current run
+  remain pending for a later resume.
 - **Credential trust is invocation-specific.** Authentication and configured
   custom headers are sent only to origins supplied as seeds in the current
   invocation. A seedless resume with credentials configured fails closed and

--- a/docs/basic-usage.ja.md
+++ b/docs/basic-usage.ja.md
@@ -106,7 +106,8 @@ exclude_patterns:
 `https://hogehoge.com/account`と`/ika/`を含むURLを拒否します。
 includeだけで許可されたoriginへは、認証情報や設定済みcustom headerを送りません。
 `^https?://.*$`のような広いincludeは、`follow_external_hosts: true`と同じ到達リスクを
-持ちます。
+持ちます。`follow_external_hosts: true`の場合、`include_patterns`では許可範囲を
+狭められません。制限には`exclude_patterns`を使用してください。
 
 ## 高度な使用例
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ This table is the authoritative reference for all options. Run `./linktadoru --h
 | request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout (Go duration) |
 | user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
 | ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
-| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Compatibility switch allowing every URL with an allowed scheme; excludes still win |
+| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Compatibility switch allowing every URL with an allowed scheme; includes do not narrow it and excludes still win |
 | limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
 | max_depth | `--max-depth` | `LT_MAX_DEPTH` | 0 | Maximum first-discovery depth; 0=unlimited, seeds=0 |
 | max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes (10 MiB) |
@@ -124,7 +124,9 @@ This allows `https://example.com/news/1` and
 `https://hogehoge.com/account` or an otherwise allowed URL containing
 `/ika/`. An include-only origin never receives authentication or configured
 custom headers. A broad include such as `^https?://.*$` has the same reach risk
-as `follow_external_hosts: true`.
+as `follow_external_hosts: true`. When `follow_external_hosts` is true,
+`include_patterns` do not narrow its allow-all scope; use `exclude_patterns` to
+restrict it.
 
 Before this change, includes narrowed an already host-limited set. Existing
 absolute cross-origin includes now actively add that range. Rewrite relative

--- a/docs/versioning-and-releases.md
+++ b/docs/versioning-and-releases.md
@@ -25,12 +25,20 @@ This project follows [Semantic Versioning](https://semver.org/):
 git checkout main
 git pull
 
-# 2. Create version tag
+# 2. Finalize and commit the matching CHANGELOG section
+#    Example: ## [1.0.0] - YYYY-MM-DD
+#    The release workflow fails if this section is missing or empty.
+
+# 3. Create version tag
 git tag v1.0.0
 
-# 3. Push tag (release workflow runs automatically)
+# 4. Push tag (release workflow runs automatically)
 git push origin v1.0.0
 ```
+
+The GitHub Release body is generated from the `CHANGELOG.md` section matching
+the tag without its `v` prefix. Finalize that section before creating the tag;
+the workflow deliberately does not fall back to an unreviewed commit list.
 
 ### 2.2 Pre-release (Beta)
 

--- a/internal/crawler/audit_fixes_test.go
+++ b/internal/crawler/audit_fixes_test.go
@@ -5,8 +5,10 @@ package crawler
 // robots.txt crawl-delay wiring.
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,6 +94,31 @@ func TestNewCrawlerRejectsInvalidPatterns(t *testing.T) {
 	cfg.ExcludePatterns = []string{"(unclosed"}
 	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "exclude pattern") {
 		t.Errorf("invalid exclude pattern: err = %v, want exclude pattern error", err)
+	}
+}
+
+func TestNewCrawlerWarnsWhenFollowExternalIgnoresIncludes(t *testing.T) {
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	cfg := &config.CrawlConfig{
+		Concurrency:         1,
+		RequestDelay:        0.1,
+		RequestTimeout:      time.Second,
+		UserAgent:           "LinkTadoru-Test/1.0",
+		FollowExternalHosts: true,
+		IncludePatterns:     []string{`^https://included\.example/only$`},
+	}
+	if _, err := NewCrawler(cfg, &MockStorage{}); err != nil {
+		t.Fatal(err)
+	}
+
+	logOutput := output.String()
+	if !strings.Contains(logOutput, "include_patterns do not narrow this mode") ||
+		!strings.Contains(logOutput, "use exclude_patterns to restrict it") {
+		t.Fatalf("warning did not explain allow-all behavior: %s", logOutput)
 	}
 }
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -106,7 +106,11 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 		return nil, fmt.Errorf("invalid URL policy: %w", err)
 	}
 	if len(config.IncludePatterns) > 0 {
-		slog.Warn("include_patterns add URL ranges; seed origins remain allowed; use exclude_patterns to narrow them")
+		if config.FollowExternalHosts {
+			slog.Warn("follow_external_hosts allows every URL with an allowed scheme; include_patterns do not narrow this mode; use exclude_patterns to restrict it")
+		} else {
+			slog.Warn("include_patterns add URL ranges; seed origins remain allowed; use exclude_patterns to narrow them")
+		}
 	}
 
 	crawler := &DefaultCrawler{

--- a/internal/crawler/issue46_integration_test.go
+++ b/internal/crawler/issue46_integration_test.go
@@ -145,6 +145,59 @@ func TestCrawlRespectsIncludePatterns(t *testing.T) {
 	}
 }
 
+func TestFollowExternalHostsIgnoresIncludesButHonorsExcludes(t *testing.T) {
+	var externalHits atomic.Int32
+	var leakedSecret atomic.Bool
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		externalHits.Add(1)
+		if r.Header.Get("X-Test-Secret") != "" {
+			leakedSecret.Store(true)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>external</body></html>"))
+	}))
+	defer external.Close()
+
+	seed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(
+			`<a href="` + external.URL + `/public">public</a>` +
+				`<a href="` + external.URL + `/private/page">private</a>`,
+		))
+	}))
+	defer seed.Close()
+
+	cfg := baseCfg()
+	cfg.SeedURLs = []string{seed.URL}
+	cfg.FollowExternalHosts = true
+	cfg.IncludePatterns = []string{`^https://included\.example/only$`}
+	cfg.ExcludePatterns = []string{`/private/`}
+	cfg.Headers = []string{"X-Test-Secret: secret"}
+
+	store := newStore(t)
+	c, err := crawler.NewCrawler(cfg, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Stop() }()
+	if err := c.Start(context.Background(), cfg.SeedURLs); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, _ := statusOf(t, store, external.URL+"/public"); got != "completed" {
+		t.Fatalf("external public URL status = %q, want completed", got)
+	}
+	if got, _ := statusOf(t, store, external.URL+"/private/page"); got != "discovered" {
+		t.Fatalf("excluded external URL status = %q, want discovered", got)
+	}
+	if got := externalHits.Load(); got != 1 {
+		t.Fatalf("external origin received %d requests, want 1", got)
+	}
+	if leakedSecret.Load() {
+		t.Fatal("configured secret header leaked to the external origin")
+	}
+}
+
 // Regression: a seed whose fetch fails at the network layer must not hang the
 // crawler. The processor returns such failures as result.Error with Page == nil,
 // which must still move the row out of 'processing' to a terminal state — else

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -69,13 +69,18 @@ func TestURLPolicyRejectsLegacyRelativeInclude(t *testing.T) {
 	}
 }
 
-func TestURLPolicyFollowExternalStillHonorsExclude(t *testing.T) {
-	policy, err := newURLPolicy(nil, nil, []string{`/private/`}, true)
+func TestURLPolicyFollowExternalIgnoresIncludeAndHonorsExclude(t *testing.T) {
+	policy, err := newURLPolicy(
+		nil,
+		[]string{`^https://included\.example/only$`},
+		[]string{`/private/`},
+		true,
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !policy.allows("https://other.example/public/page") {
-		t.Fatal("follow_external_hosts did not allow an external URL")
+		t.Fatal("include_patterns unexpectedly narrowed follow_external_hosts")
 	}
 	if policy.allows("https://other.example/private/page") {
 		t.Fatal("exclude did not override follow_external_hosts")


### PR DESCRIPTION
## Why

The next release contains deliberate compatibility changes that a raw commit list would hide. It also needs a precise warning for the existing `follow_external_hosts: true` plus `include_patterns` combination, where allow-all wins and only excludes narrow scope.

## What changed

- Add a dedicated startup warning for that allow-all combination.
- Add unit and real two-origin crawl coverage proving that includes do not narrow it, excludes still win, external URLs are fetched, and configured secret headers are not sent externally.
- Rewrite the Unreleased changelog with compatibility and upgrade notes first, covering #67, #68, #71, #72, #79, security behavior, dependencies, and known limitations.
- Generate GitHub Release notes from the changelog section matching the tag, and fail if that section is missing or empty.
- Document the required changelog-finalization step before tagging.

## Compatibility notes

The changelog prominently calls out URL-policy semantics, external-host reach, first-admission depth, legacy database migration, seed refresh behavior, CLI seed precedence, and invocation-specific credential trust. The code change in this PR does not expand URL reach; it makes the already-shipped allow-all behavior explicit.

## Verification

- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `go test ./... -count=1 -race`
- Targeted policy, warning, and two-origin integration tests
- Workflow YAML parse and generated shell syntax check
- Changelog extraction succeeds for a matching non-empty section and fails for a missing version

## Release boundary

The changelog remains `[Unreleased]`. Before tagging, it must be renamed to the chosen version and date. This PR does not create a tag or GitHub Release.