### PR TITLE
Finalize the v0.11.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-07
+
+Versioning note: v0.10.0 was withdrawn. This release uses v0.11.0 instead of
+reusing a version number that had already been published.
+
 ### Compatibility and upgrade notes
 - **URL include semantics changed from filtering to authorization.** Persisted
   depth-0 seed origins are always allowed; `include_patterns` now add absolute


### PR DESCRIPTION
## Summary

- Keep an empty `[Unreleased]` section for future changes.
- Date the reviewed compatibility-first notes as v0.11.0.
- Record that v0.10.0 was withdrawn and its published version number is not being reused.

## Verification

- The release workflow extraction logic finds a non-empty `## [0.11.0]` section.
- The extracted section contains the versioning note, compatibility notes, security notes, and known limitations.
- `git diff --check` passes.

This PR changes only `CHANGELOG.md`. It does not create the tag or GitHub Release.