### PR TITLE
Redact secrets from --show-config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `<redacted>` in both the configuration dump and the validation warnings on
   stderr. Provenance fields such as `token_env` and header names remain visible,
   and the crawler still receives the real values at runtime (#90).
+- The startup banner no longer prints the resolved basic-auth username, and it
+  now reports bearer and API-key runs instead of labelling them
+  `Authentication: None`. The banner runs on every crawl, so it leaked the same
+  value `--show-config` redacts (#90).
 
 ## [0.11.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   now reports bearer and API-key runs instead of labelling them
   `Authentication: None`. The banner runs on every crawl, so it leaked the same
   value `--show-config` redacts (#90).
+- Configuration errors and warnings no longer quote the secret that caused
+  them. A malformed `-H` header used to reach stderr with its value intact, a
+  seed URL rejected for carrying userinfo used to reach stderr with its
+  credentials intact, and the crawler logged skipped headers in full. All three
+  run without `--show-config`, so they leaked on the default path. Redaction
+  now lives in one place (`internal/redact`) shared by the diagnostic dump, the
+  validation errors, and the logs (#90).
 
 ## [0.11.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Security
+- `--show-config` no longer prints resolved secrets. Basic-auth usernames and
+  passwords, bearer tokens, API-key values, every custom header value including
+  those loaded from `LT_HEADER_*`, and seed-URL userinfo are replaced with
+  `<redacted>` in both the configuration dump and the validation warnings on
+  stderr. Provenance fields such as `token_env` and header names remain visible,
+  and the crawler still receives the real values at runtime (#90).
+
 ## [0.11.0] - 2026-08-07
 
 Versioning note: v0.10.0 was withdrawn. This release uses v0.11.0 instead of

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,12 @@ export LT_HEADER_X_CUSTOM="MyCustomValue"
 ./linktadoru https://httpbin.org
 ```
 
+A header set this way replaces one of the same name coming from the
+configuration file or `--header`, and is otherwise appended to that list. A
+rejected header is reported by its position in the resulting list, which is not
+necessarily its line number in the configuration file. The value is never
+quoted back in the error.
+
 ## Logging
 
 Logging is configured in the configuration file only (no CLI flags or environment variables):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -45,7 +45,7 @@ This table is the authoritative reference for all options. Run `./linktadoru --h
 | log_max_size | - | - | 100 | Max log file size in MB before rotation (config file only) |
 | log_max_backups | - | - | 5 | Number of rotated log files to keep (config file only) |
 | **Other** |
-| show_config | `--show-config` | - | false | Display current configuration and exit |
+| show_config | `--show-config` | - | false | Display current configuration with secret values redacted, then exit |
 
 ## Configuration File
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -5,6 +5,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -26,6 +28,8 @@ var (
 	version   string
 	buildTime string
 )
+
+const redactedConfigValue = "<redacted>"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -166,38 +170,127 @@ func generateUserAgent() string {
 	return "LinkTadoru/dev"
 }
 
-func showCurrentConfig(cfg *config.CrawlConfig) error {
+func showCurrentConfig(cmd *cobra.Command, cfg *config.CrawlConfig) error {
 	if cfg == nil {
 		return fmt.Errorf("configuration is nil")
 	}
-
-	// Validate configuration before showing it
-	if err := cfg.Validate(); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: Configuration validation failed: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Displaying configuration anyway...\n\n")
+	if cmd == nil {
+		return fmt.Errorf("command is nil")
 	}
 
-	yamlData, err := yaml.Marshal(cfg)
+	displayConfig := redactConfigForDisplay(cfg)
+	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
+
+	// Validate configuration before showing it
+	if err := displayConfig.Validate(); err != nil {
+		warning := fmt.Sprintf("Warning: Configuration validation failed: %v\n", err) +
+			"Displaying configuration anyway...\n\n"
+		// Best effort: the configuration below is still worth printing even if
+		// this diagnostic cannot be delivered.
+		_, _ = io.WriteString(stderr, warning)
+	}
+
+	yamlData, err := yaml.Marshal(displayConfig)
 	if err != nil {
 		return fmt.Errorf("failed to marshal configuration to YAML: %w", err)
 	}
 
-	// Add header comment to the output
-	fmt.Printf("# Current LinkTadoru Configuration\n")
-	fmt.Printf("# Generated at: %s\n", time.Now().Format(time.RFC3339))
-	fmt.Printf("# Configuration file search paths: ./linktadoru.yml\n")
-	fmt.Printf("# Environment variables prefix: LT_\n\n")
+	header := fmt.Sprintf("# Current LinkTadoru Configuration\n"+
+		"# Generated at: %s\n"+
+		"# Configuration file search paths: ./linktadoru.yml\n"+
+		"# Environment variables prefix: LT_\n\n",
+		time.Now().Format(time.RFC3339))
 
-	fmt.Print(string(yamlData))
+	footer := "\n# Configuration source priority:\n" +
+		"# 1. Command-line arguments (highest priority)\n" +
+		"# 2. Environment variables (LT_ prefix)\n" +
+		"# 3. Configuration file (linktadoru.yml)\n" +
+		"# 4. Default values (lowest priority)\n"
 
-	// Add footer with additional information
-	fmt.Printf("\n# Configuration source priority:\n")
-	fmt.Printf("# 1. Command-line arguments (highest priority)\n")
-	fmt.Printf("# 2. Environment variables (LT_ prefix)\n")
-	fmt.Printf("# 3. Configuration file (linktadoru.yml)\n")
-	fmt.Printf("# 4. Default values (lowest priority)\n")
+	if _, err := io.WriteString(stdout, header+string(yamlData)+footer); err != nil {
+		return fmt.Errorf("failed to write configuration: %w", err)
+	}
 
 	return nil
+}
+
+func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
+	redacted := *cfg
+
+	redacted.SeedURLs = make([]string, len(cfg.SeedURLs))
+	for i, seedURL := range cfg.SeedURLs {
+		redacted.SeedURLs[i] = redactSeedURLForDisplay(seedURL)
+	}
+	redacted.IncludePatterns = append([]string(nil), cfg.IncludePatterns...)
+	redacted.ExcludePatterns = append([]string(nil), cfg.ExcludePatterns...)
+	redacted.AllowedSchemes = append([]string(nil), cfg.AllowedSchemes...)
+	redacted.Headers = make([]string, len(cfg.Headers))
+	for i, header := range cfg.Headers {
+		redacted.Headers[i] = redactHeaderForDisplay(header)
+	}
+
+	if cfg.Auth == nil {
+		return &redacted
+	}
+
+	auth := *cfg.Auth
+	redacted.Auth = &auth
+
+	if cfg.Auth.Basic != nil {
+		basic := *cfg.Auth.Basic
+		if basic.Username != "" {
+			basic.Username = redactedConfigValue
+		}
+		if basic.Password != "" {
+			basic.Password = redactedConfigValue
+		}
+		auth.Basic = &basic
+	}
+
+	if cfg.Auth.Bearer != nil {
+		bearer := *cfg.Auth.Bearer
+		if bearer.Token != "" {
+			bearer.Token = redactedConfigValue
+		}
+		auth.Bearer = &bearer
+	}
+
+	if cfg.Auth.APIKey != nil {
+		apiKey := *cfg.Auth.APIKey
+		if apiKey.Value != "" {
+			apiKey.Value = redactedConfigValue
+		}
+		auth.APIKey = &apiKey
+	}
+
+	return &redacted
+}
+
+func redactSeedURLForDisplay(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return redactedConfigValue
+	}
+	if parsed.User == nil {
+		return raw
+	}
+	parsed.User = url.User("redacted")
+	return parsed.String()
+}
+
+func redactHeaderForDisplay(header string) string {
+	name, value, found := strings.Cut(header, ":")
+	if !found {
+		return redactedConfigValue
+	}
+	if strings.TrimSpace(name) == "" {
+		return ": " + redactedConfigValue
+	}
+	if strings.TrimSpace(value) == "" {
+		return strings.TrimSpace(name) + ":"
+	}
+	return strings.TrimSpace(name) + ": " + redactedConfigValue
 }
 
 func applySeedURLs(cmd *cobra.Command, args []string, cfg *config.CrawlConfig) error {
@@ -248,7 +341,7 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 
 	// Handle --show-config: display current configuration and exit
 	if showConfig {
-		return showCurrentConfig(cfg)
+		return showCurrentConfig(cmd, cfg)
 	}
 
 	// Initialize logging

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -215,6 +215,22 @@ func showCurrentConfig(cmd *cobra.Command, cfg *config.CrawlConfig) error {
 	return nil
 }
 
+// describeAuthForDisplay reports which credential the run will send without
+// revealing any part of it. Only the API-key header name is shown, because it
+// names the field rather than the secret carried in it.
+func describeAuthForDisplay(cfg *config.CrawlConfig) string {
+	if username, password := cfg.GetBasicAuthCredentials(); username != "" && password != "" {
+		return "Basic (username and password redacted)"
+	}
+	if token := cfg.GetBearerToken(); token != "" {
+		return "Bearer (token redacted)"
+	}
+	if header, value := cfg.GetAPIKeyCredentials(); header != "" && value != "" {
+		return fmt.Sprintf("API key (%s value redacted)", header)
+	}
+	return "None"
+}
+
 func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
 	redacted := *cfg
 
@@ -415,12 +431,9 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Database: %s\n", cfg.DatabasePath)
 	fmt.Printf("  Ignore Robots.txt: %t\n", cfg.IgnoreRobotsTxt)
 
-	// Display auth status without exposing credentials
-	if username, password := cfg.GetBasicAuthCredentials(); username != "" && password != "" {
-		fmt.Printf("  Authentication: Basic (username: %s)\n", username)
-	} else {
-		fmt.Printf("  Authentication: None\n")
-	}
+	// Display auth status without exposing credentials. The username is part of
+	// the credential, so it is named as configured but never printed.
+	fmt.Printf("  Authentication: %s\n", describeAuthForDisplay(cfg))
 
 	// Initialize and start the crawler
 	crawler, store, err := initializeCrawler(cfg)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/masahif/linktadoru/internal/config"
 	"github.com/masahif/linktadoru/internal/crawler"
 	"github.com/masahif/linktadoru/internal/logging"
+	"github.com/masahif/linktadoru/internal/redact"
 	"github.com/masahif/linktadoru/internal/storage"
 )
 
@@ -28,8 +28,6 @@ var (
 	version   string
 	buildTime string
 )
-
-const redactedConfigValue = "<redacted>"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -236,14 +234,14 @@ func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
 
 	redacted.SeedURLs = make([]string, len(cfg.SeedURLs))
 	for i, seedURL := range cfg.SeedURLs {
-		redacted.SeedURLs[i] = redactSeedURLForDisplay(seedURL)
+		redacted.SeedURLs[i] = redact.URL(seedURL)
 	}
 	redacted.IncludePatterns = append([]string(nil), cfg.IncludePatterns...)
 	redacted.ExcludePatterns = append([]string(nil), cfg.ExcludePatterns...)
 	redacted.AllowedSchemes = append([]string(nil), cfg.AllowedSchemes...)
 	redacted.Headers = make([]string, len(cfg.Headers))
 	for i, header := range cfg.Headers {
-		redacted.Headers[i] = redactHeaderForDisplay(header)
+		redacted.Headers[i] = redact.Header(header)
 	}
 
 	if cfg.Auth == nil {
@@ -256,10 +254,10 @@ func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
 	if cfg.Auth.Basic != nil {
 		basic := *cfg.Auth.Basic
 		if basic.Username != "" {
-			basic.Username = redactedConfigValue
+			basic.Username = redact.Value
 		}
 		if basic.Password != "" {
-			basic.Password = redactedConfigValue
+			basic.Password = redact.Value
 		}
 		auth.Basic = &basic
 	}
@@ -267,7 +265,7 @@ func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
 	if cfg.Auth.Bearer != nil {
 		bearer := *cfg.Auth.Bearer
 		if bearer.Token != "" {
-			bearer.Token = redactedConfigValue
+			bearer.Token = redact.Value
 		}
 		auth.Bearer = &bearer
 	}
@@ -275,38 +273,12 @@ func redactConfigForDisplay(cfg *config.CrawlConfig) *config.CrawlConfig {
 	if cfg.Auth.APIKey != nil {
 		apiKey := *cfg.Auth.APIKey
 		if apiKey.Value != "" {
-			apiKey.Value = redactedConfigValue
+			apiKey.Value = redact.Value
 		}
 		auth.APIKey = &apiKey
 	}
 
 	return &redacted
-}
-
-func redactSeedURLForDisplay(raw string) string {
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return redactedConfigValue
-	}
-	if parsed.User == nil {
-		return raw
-	}
-	parsed.User = url.User("redacted")
-	return parsed.String()
-}
-
-func redactHeaderForDisplay(header string) string {
-	name, value, found := strings.Cut(header, ":")
-	if !found {
-		return redactedConfigValue
-	}
-	if strings.TrimSpace(name) == "" {
-		return ": " + redactedConfigValue
-	}
-	if strings.TrimSpace(value) == "" {
-		return strings.TrimSpace(name) + ":"
-	}
-	return strings.TrimSpace(name) + ": " + redactedConfigValue
 }
 
 func applySeedURLs(cmd *cobra.Command, args []string, cfg *config.CrawlConfig) error {
@@ -432,7 +404,7 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Ignore Robots.txt: %t\n", cfg.IgnoreRobotsTxt)
 
 	// Display auth status without exposing credentials. The username is part of
-	// the credential, so it is named as configured but never printed.
+	// the credential, so only the credential kind is reported.
 	fmt.Printf("  Authentication: %s\n", describeAuthForDisplay(cfg))
 
 	// Initialize and start the crawler

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -229,6 +229,71 @@ func TestShowCurrentConfigRedactsInvalidHeaderValidationError(t *testing.T) {
 	}
 }
 
+func TestDescribeAuthForDisplayHidesCredentials(t *testing.T) {
+	t.Setenv("BANNER_BASIC_PASSWORD", "banner-password-secret")
+	t.Setenv("BANNER_BEARER_TOKEN", "banner-bearer-secret")
+	t.Setenv("BANNER_API_KEY_VALUE", "banner-api-key-secret")
+
+	tests := []struct {
+		name    string
+		auth    *config.Auth
+		want    string
+		secrets []string
+	}{
+		{
+			name: "no auth",
+			want: "None",
+		},
+		{
+			name: "basic with env password",
+			auth: &config.Auth{
+				Type: config.BasicAuthType,
+				Basic: &config.BasicAuth{
+					Username:    "banner-username-secret",
+					PasswordEnv: "BANNER_BASIC_PASSWORD",
+				},
+			},
+			want:    "Basic (username and password redacted)",
+			secrets: []string{"banner-username-secret", "banner-password-secret"},
+		},
+		{
+			name: "bearer from env",
+			auth: &config.Auth{
+				Type:   config.BearerAuthType,
+				Bearer: &config.BearerAuth{TokenEnv: "BANNER_BEARER_TOKEN"},
+			},
+			want:    "Bearer (token redacted)",
+			secrets: []string{"banner-bearer-secret"},
+		},
+		{
+			name: "api key from env",
+			auth: &config.Auth{
+				Type:   config.APIKeyAuthType,
+				APIKey: &config.APIKeyAuth{Header: "X-API-Key", ValueEnv: "BANNER_API_KEY_VALUE"},
+			},
+			want:    "API key (X-API-Key value redacted)",
+			secrets: []string{"banner-api-key-secret"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Auth = tt.auth
+
+			got := describeAuthForDisplay(cfg)
+			if got != tt.want {
+				t.Errorf("describeAuthForDisplay() = %q, want %q", got, tt.want)
+			}
+			for _, secret := range tt.secrets {
+				if strings.Contains(got, secret) {
+					t.Errorf("describeAuthForDisplay() leaked secret %q", secret)
+				}
+			}
+		})
+	}
+}
+
 func TestInitializeCrawler(t *testing.T) {
 	// Create a temporary database
 	tempDir := t.TempDir()

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/masahif/linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/redact"
 	"github.com/masahif/linktadoru/internal/storage"
 )
 
@@ -165,7 +166,7 @@ func TestShowCurrentConfigRedactsSecrets(t *testing.T) {
 	}
 
 	visibleMetadata := []string{
-		redactedConfigValue,
+		redact.Value,
 		"username_env: BASIC_USERNAME",
 		"password_env: BASIC_PASSWORD",
 		"token_env: BEARER_TOKEN",
@@ -224,7 +225,7 @@ func TestShowCurrentConfigRedactsInvalidHeaderValidationError(t *testing.T) {
 	if !strings.Contains(stderr.String(), "Configuration validation failed") {
 		t.Fatalf("stderr does not contain the expected validation warning: %s", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), redactedConfigValue) {
+	if !strings.Contains(stderr.String(), redact.Value) {
 		t.Fatalf("stderr does not contain the redaction marker: %s", stderr.String())
 	}
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -86,6 +87,145 @@ func TestRootCmd(t *testing.T) {
 
 	if rootCmd.RunE == nil {
 		t.Error("RunE should be set to runCrawler")
+	}
+}
+
+func TestShowCurrentConfigRedactsSecrets(t *testing.T) {
+	t.Setenv("BASIC_USERNAME", "basic-env-username-secret")
+	t.Setenv("BASIC_PASSWORD", "basic-env-password-secret")
+	t.Setenv("BEARER_TOKEN", "bearer-env-secret")
+	t.Setenv("API_KEY_VALUE", "api-key-env-secret")
+	t.Setenv("LT_HEADER_AUTHORIZATION", "Bearer env-header-secret")
+	t.Setenv("LT_HEADER_COOKIE", "session=env-cookie-secret")
+	t.Setenv("LT_HEADER_X_CUSTOM", "env-custom-secret")
+
+	cfg := config.DefaultConfig()
+	cfg.SeedURLs = []string{
+		"https://seed-user-secret:seed-password-secret@example.com/private",
+		"https://public.example/",
+	}
+	cfg.Auth = &config.Auth{
+		Type: config.BasicAuthType,
+		Basic: &config.BasicAuth{
+			Username:    "direct-username-secret",
+			Password:    "direct-password-secret",
+			UsernameEnv: "BASIC_USERNAME",
+			PasswordEnv: "BASIC_PASSWORD",
+		},
+		Bearer: &config.BearerAuth{
+			Token:    "direct-bearer-secret",
+			TokenEnv: "BEARER_TOKEN",
+		},
+		APIKey: &config.APIKeyAuth{
+			Header:   "X-API-Key",
+			Value:    "direct-api-key-secret",
+			ValueEnv: "API_KEY_VALUE",
+		},
+	}
+	cfg.Headers = []string{
+		"X-Direct: direct-header-secret",
+		"malformed-header-secret",
+	}
+	cfg.LoadHeadersFromEnv()
+
+	originalHeaders := append([]string(nil), cfg.Headers...)
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := showCurrentConfig(cmd, cfg); err != nil {
+		t.Fatalf("showCurrentConfig() error = %v", err)
+	}
+
+	output := stdout.String() + stderr.String()
+	secrets := []string{
+		"direct-username-secret",
+		"direct-password-secret",
+		"direct-bearer-secret",
+		"direct-api-key-secret",
+		"direct-header-secret",
+		"malformed-header-secret",
+		"basic-env-username-secret",
+		"basic-env-password-secret",
+		"bearer-env-secret",
+		"api-key-env-secret",
+		"env-header-secret",
+		"env-cookie-secret",
+		"env-custom-secret",
+		"seed-user-secret",
+		"seed-password-secret",
+	}
+	for _, secret := range secrets {
+		if strings.Contains(output, secret) {
+			t.Errorf("show-config output leaked secret %q", secret)
+		}
+	}
+
+	visibleMetadata := []string{
+		redactedConfigValue,
+		"username_env: BASIC_USERNAME",
+		"password_env: BASIC_PASSWORD",
+		"token_env: BEARER_TOKEN",
+		"value_env: API_KEY_VALUE",
+		"header: X-API-Key",
+		"X-Direct: <redacted>",
+		"Authorization: <redacted>",
+		"Cookie: <redacted>",
+		"X-Custom: <redacted>",
+		"https://redacted@example.com/private",
+		"https://public.example/",
+	}
+	for _, want := range visibleMetadata {
+		if !strings.Contains(output, want) {
+			t.Errorf("show-config output does not contain %q\noutput:\n%s", want, output)
+		}
+	}
+
+	if cfg.Auth.Basic.Username != "direct-username-secret" || cfg.Auth.Basic.Password != "direct-password-secret" {
+		t.Fatal("showCurrentConfig mutated the runtime basic-auth configuration")
+	}
+	if cfg.Auth.Bearer.Token != "direct-bearer-secret" {
+		t.Fatal("showCurrentConfig mutated the runtime bearer configuration")
+	}
+	if cfg.Auth.APIKey.Value != "direct-api-key-secret" {
+		t.Fatal("showCurrentConfig mutated the runtime API-key configuration")
+	}
+	if len(cfg.Headers) != len(originalHeaders) {
+		t.Fatal("showCurrentConfig mutated the runtime header list")
+	}
+	for i := range originalHeaders {
+		if cfg.Headers[i] != originalHeaders[i] {
+			t.Fatalf("showCurrentConfig mutated header %d: got %q, want %q", i, cfg.Headers[i], originalHeaders[i])
+		}
+	}
+}
+
+func TestShowCurrentConfigRedactsInvalidHeaderValidationError(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Headers = []string{"invalid-header-secret"}
+
+	cmd := &cobra.Command{}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	if err := showCurrentConfig(cmd, cfg); err != nil {
+		t.Fatalf("showCurrentConfig() error = %v", err)
+	}
+
+	output := stdout.String() + stderr.String()
+	if strings.Contains(output, "invalid-header-secret") {
+		t.Fatal("show-config validation output leaked an invalid header value")
+	}
+	if !strings.Contains(stderr.String(), "Configuration validation failed") {
+		t.Fatalf("stderr does not contain the expected validation warning: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), redactedConfigValue) {
+		t.Fatalf("stderr does not contain the redaction marker: %s", stderr.String())
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,29 +317,34 @@ func (c *CrawlConfig) validateAPIKeyAuth() error {
 
 // validateHeaders validates HTTP headers format
 func (c *CrawlConfig) validateHeaders() error {
-	for _, header := range c.Headers {
+	for i, header := range c.Headers {
+		// The header is identified by position as well as by its redacted form:
+		// a header with no usable name redacts to a marker that says nothing
+		// about which of several configured headers was rejected.
+		position := i + 1
+
 		// Check if header has proper format "Name: Value"
 		colonIndex := strings.Index(header, ":")
 		if colonIndex <= 0 {
-			return fmt.Errorf("invalid header format '%s': expected 'Name: Value'", redact.Header(header))
+			return fmt.Errorf("invalid header %d '%s': expected 'Name: Value'", position, redact.Header(header))
 		}
 
 		headerName := strings.TrimSpace(header[:colonIndex])
 		headerValue := strings.TrimSpace(header[colonIndex+1:])
 
 		if headerName == "" {
-			return fmt.Errorf("invalid header format '%s': header name cannot be empty", redact.Header(header))
+			return fmt.Errorf("invalid header %d '%s': header name cannot be empty", position, redact.Header(header))
 		}
 
 		if headerValue == "" {
-			return fmt.Errorf("invalid header format '%s': header value cannot be empty", redact.Header(header))
+			return fmt.Errorf("invalid header %d '%s': header value cannot be empty", position, redact.Header(header))
 		}
 
 		// Check for forbidden headers that should not be set manually
 		forbiddenHeaders := []string{"host", "content-length", "connection"}
 		for _, forbidden := range forbiddenHeaders {
 			if strings.EqualFold(headerName, forbidden) {
-				return fmt.Errorf("cannot set forbidden header '%s'", headerName)
+				return fmt.Errorf("invalid header %d: cannot set forbidden header '%s'", position, headerName)
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/masahif/linktadoru/internal/redact"
 )
 
 // BasicAuth contains HTTP Basic Authentication credentials
@@ -319,18 +321,18 @@ func (c *CrawlConfig) validateHeaders() error {
 		// Check if header has proper format "Name: Value"
 		colonIndex := strings.Index(header, ":")
 		if colonIndex <= 0 {
-			return fmt.Errorf("invalid header format '%s': expected 'Name: Value'", header)
+			return fmt.Errorf("invalid header format '%s': expected 'Name: Value'", redact.Header(header))
 		}
 
 		headerName := strings.TrimSpace(header[:colonIndex])
 		headerValue := strings.TrimSpace(header[colonIndex+1:])
 
 		if headerName == "" {
-			return fmt.Errorf("invalid header format '%s': header name cannot be empty", header)
+			return fmt.Errorf("invalid header format '%s': header name cannot be empty", redact.Header(header))
 		}
 
 		if headerValue == "" {
-			return fmt.Errorf("invalid header format '%s': header value cannot be empty", header)
+			return fmt.Errorf("invalid header format '%s': header value cannot be empty", redact.Header(header))
 		}
 
 		// Check for forbidden headers that should not be set manually

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -430,25 +430,25 @@ func TestValidateHeaders(t *testing.T) {
 			name:    "invalid header format - no colon",
 			headers: []string{"InvalidHeader"},
 			wantErr: true,
-			errMsg:  "invalid header format 'InvalidHeader': expected 'Name: Value'",
+			errMsg:  "invalid header format '<redacted>': expected 'Name: Value'",
 		},
 		{
 			name:    "invalid header format - colon at start",
 			headers: []string{":Value"},
 			wantErr: true,
-			errMsg:  "invalid header format ':Value': expected 'Name: Value'",
+			errMsg:  "invalid header format ': <redacted>': expected 'Name: Value'",
 		},
 		{
 			name:    "empty header name",
 			headers: []string{" : Value"},
 			wantErr: true,
-			errMsg:  "invalid header format ' : Value': header name cannot be empty",
+			errMsg:  "invalid header format ': <redacted>': header name cannot be empty",
 		},
 		{
 			name:    "empty header value",
 			headers: []string{"Name: "},
 			wantErr: true,
-			errMsg:  "invalid header format 'Name: ': header value cannot be empty",
+			errMsg:  "invalid header format 'Name:': header value cannot be empty",
 		},
 		{
 			name:    "forbidden header - host",
@@ -486,6 +486,38 @@ func TestValidateHeaders(t *testing.T) {
 			}
 			if tt.wantErr && tt.errMsg != "" && err.Error() != tt.errMsg {
 				t.Errorf("Validate() error = %v, want error containing %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestValidateHeadersDoesNotLeakHeaderValues(t *testing.T) {
+	// The validation error is printed to stderr on the normal startup path, so
+	// it must not quote the value it rejects.
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"no colon", "header-value-secret"},
+		{"empty name", " : header-value-secret"},
+		{"empty value", "X-Empty:   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &CrawlConfig{
+				Concurrency:    2,
+				RequestDelay:   0.1,
+				RequestTimeout: 30 * time.Second,
+				DatabasePath:   "./test.db",
+				Headers:        []string{tt.header},
+			}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error for header %q", tt.header)
+			}
+			if strings.Contains(err.Error(), "secret") {
+				t.Errorf("Validate() error leaked the header value: %v", err)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -430,43 +430,43 @@ func TestValidateHeaders(t *testing.T) {
 			name:    "invalid header format - no colon",
 			headers: []string{"InvalidHeader"},
 			wantErr: true,
-			errMsg:  "invalid header format '<redacted>': expected 'Name: Value'",
+			errMsg:  "invalid header 1 '<redacted>': expected 'Name: Value'",
 		},
 		{
 			name:    "invalid header format - colon at start",
 			headers: []string{":Value"},
 			wantErr: true,
-			errMsg:  "invalid header format ': <redacted>': expected 'Name: Value'",
+			errMsg:  "invalid header 1 ': <redacted>': expected 'Name: Value'",
 		},
 		{
 			name:    "empty header name",
 			headers: []string{" : Value"},
 			wantErr: true,
-			errMsg:  "invalid header format ': <redacted>': header name cannot be empty",
+			errMsg:  "invalid header 1 ': <redacted>': header name cannot be empty",
 		},
 		{
 			name:    "empty header value",
 			headers: []string{"Name: "},
 			wantErr: true,
-			errMsg:  "invalid header format 'Name:': header value cannot be empty",
+			errMsg:  "invalid header 1 'Name:': header value cannot be empty",
 		},
 		{
 			name:    "forbidden header - host",
 			headers: []string{"Host: example.com"},
 			wantErr: true,
-			errMsg:  "cannot set forbidden header 'Host'",
+			errMsg:  "invalid header 1: cannot set forbidden header 'Host'",
 		},
 		{
 			name:    "forbidden header - content-length",
 			headers: []string{"Content-Length: 100"},
 			wantErr: true,
-			errMsg:  "cannot set forbidden header 'Content-Length'",
+			errMsg:  "invalid header 1: cannot set forbidden header 'Content-Length'",
 		},
 		{
 			name:    "forbidden header - connection",
 			headers: []string{"Connection: keep-alive"},
 			wantErr: true,
-			errMsg:  "cannot set forbidden header 'Connection'",
+			errMsg:  "invalid header 1: cannot set forbidden header 'Connection'",
 		},
 	}
 
@@ -500,7 +500,7 @@ func TestValidateHeadersDoesNotLeakHeaderValues(t *testing.T) {
 	}{
 		{"no colon", "header-value-secret"},
 		{"empty name", " : header-value-secret"},
-		{"empty value", "X-Empty:   "},
+		{"forbidden header", "Host: host-value-secret"},
 	}
 
 	for _, tt := range tests {
@@ -510,7 +510,7 @@ func TestValidateHeadersDoesNotLeakHeaderValues(t *testing.T) {
 				RequestDelay:   0.1,
 				RequestTimeout: 30 * time.Second,
 				DatabasePath:   "./test.db",
-				Headers:        []string{tt.header},
+				Headers:        []string{"X-Valid: fine", tt.header},
 			}
 			err := cfg.Validate()
 			if err == nil {
@@ -518,6 +518,9 @@ func TestValidateHeadersDoesNotLeakHeaderValues(t *testing.T) {
 			}
 			if strings.Contains(err.Error(), "secret") {
 				t.Errorf("Validate() error leaked the header value: %v", err)
+			}
+			if !strings.Contains(err.Error(), "2") {
+				t.Errorf("Validate() error does not identify which header was rejected: %v", err)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -519,7 +519,7 @@ func TestValidateHeadersDoesNotLeakHeaderValues(t *testing.T) {
 			if strings.Contains(err.Error(), "secret") {
 				t.Errorf("Validate() error leaked the header value: %v", err)
 			}
-			if !strings.Contains(err.Error(), "2") {
+			if !strings.Contains(err.Error(), "invalid header 2") {
 				t.Errorf("Validate() error does not identify which header was rejected: %v", err)
 			}
 		})

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/masahif/linktadoru/internal/config"
+	"github.com/masahif/linktadoru/internal/redact"
 )
 
 // DefaultCrawler implements the Crawler interface
@@ -69,7 +70,7 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 			colonIndex := strings.Index(header, ":")
 			if colonIndex <= 0 {
 				// Skip invalid headers - validation should have caught this
-				slog.Warn("Skipping invalid header format", "header", header)
+				slog.Warn("Skipping invalid header format", "header", redact.Header(header))
 				continue
 			}
 
@@ -78,7 +79,7 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 
 			if key == "" || value == "" {
 				// Skip empty key or value
-				slog.Warn("Skipping header with empty key or value", "header", header)
+				slog.Warn("Skipping header with empty key or value", "header", redact.Header(header))
 				continue
 			}
 

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -1,6 +1,9 @@
 package crawler
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestURLPolicyImplicitOriginAndExclude(t *testing.T) {
 	policy, err := newURLPolicy(
@@ -90,5 +93,26 @@ func TestURLPolicyFollowExternalIgnoresIncludeAndHonorsExclude(t *testing.T) {
 func TestCompilePatternsRejectsInvalidRegexp(t *testing.T) {
 	if _, err := compilePatterns([]string{"["}); err == nil {
 		t.Fatal("invalid regexp was accepted")
+	}
+}
+
+func TestValidateExplicitURLsDoesNotLeakUserinfo(t *testing.T) {
+	// A seed carrying userinfo is always rejected, and the resulting error
+	// reaches stderr on the normal startup path, so it must not quote the
+	// credential it rejects.
+	policy, err := newURLPolicy([]string{"https://"}, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = policy.validateExplicitURLs([]string{"https://user-secret:pass-secret@example.com/private"})
+	if err == nil {
+		t.Fatal("validateExplicitURLs() = nil, want an error for a seed URL with userinfo")
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Errorf("validateExplicitURLs() error leaked the credential: %v", err)
+	}
+	if !strings.Contains(err.Error(), "example.com") {
+		t.Errorf("validateExplicitURLs() error does not identify the seed: %v", err)
 	}
 }

--- a/internal/crawler/url_policy.go
+++ b/internal/crawler/url_policy.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/masahif/linktadoru/internal/redact"
 )
 
 // urlPolicy is the crawler's single URL authorization decision. Persisted
@@ -82,7 +84,7 @@ func (p *urlPolicy) setImplicitOrigins(urls []string) error {
 func (p *urlPolicy) validateExplicitURLs(urls []string) error {
 	for _, raw := range urls {
 		if _, _, err := p.parse(raw); err != nil {
-			return fmt.Errorf("invalid seed URL %q: %w", raw, err)
+			return fmt.Errorf("invalid seed URL %q: %w", redact.URL(raw), err)
 		}
 	}
 	return nil

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -24,6 +24,17 @@ func URL(raw string) string {
 	if err != nil {
 		return Value
 	}
+	// Without an authority there is no parsed userinfo to strip, and url.Parse
+	// does not report an error for such input. "user:pass@host/path" parses as
+	// an opaque URL with scheme "user", which would otherwise pass through
+	// whole. Anything that carries "@" but no host is replaced entirely, since
+	// there is no way to tell which part of it is the credential.
+	if parsed.Host == "" {
+		if strings.Contains(raw, "@") {
+			return Value
+		}
+		return raw
+	}
 	if parsed.User == nil {
 		return raw
 	}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,49 @@
+// Package redact renders configuration values that may carry credentials in a
+// form safe to print. Diagnostics, validation errors, and logs all quote the
+// input that caused them, so each of those sites needs the same rendering — a
+// single implementation here keeps them from drifting apart.
+package redact
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Value is the marker substituted for a secret. It is stable so that output
+// can be asserted on and so operators can recognize it.
+const Value = "<redacted>"
+
+// URL removes userinfo credentials from raw, keeping the rest of the URL so it
+// remains recognizable. A URL that cannot be parsed is replaced entirely,
+// because there is no way to tell which part of it is a credential.
+//
+// Credentials carried in a query string are not removed; deciding what a query
+// parameter is allowed to contain is a separate policy question.
+func URL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return Value
+	}
+	if parsed.User == nil {
+		return raw
+	}
+	parsed.User = url.User("redacted")
+	return parsed.String()
+}
+
+// Header replaces the value of a "Name: Value" header with the marker, keeping
+// the name. A header that does not carry a usable name is replaced entirely,
+// since the whole string may then be the secret.
+func Header(header string) string {
+	name, value, found := strings.Cut(header, ":")
+	if !found {
+		return Value
+	}
+	if strings.TrimSpace(name) == "" {
+		return ": " + Value
+	}
+	if strings.TrimSpace(value) == "" {
+		return strings.TrimSpace(name) + ":"
+	}
+	return strings.TrimSpace(name) + ": " + Value
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -15,6 +15,12 @@ func TestURL(t *testing.T) {
 		{"username and password", "https://user-secret:pass-secret@example.com/p", "https://redacted@example.com/p"},
 		{"username only", "https://user-secret@example.com/p", "https://redacted@example.com/p"},
 		{"unparsable", "https://exa mple.com/\x7f", Value},
+		{"schemeless with credentials", "user-secret:pass-secret@example.com/p", Value},
+		{"schemeless with username", "user-secret@example.com/p", Value},
+		{"at sign in path", "https://example.com/@handle", "https://example.com/@handle"},
+		{"ipv6 host", "https://user-secret:pass-secret@[::1]:8080/p", "https://redacted@[::1]:8080/p"},
+		{"password only", "https://:pass-secret@example.com/", "https://redacted@example.com/"},
+		{"relative path", "/local/path", "/local/path"},
 		{"empty", "", ""},
 	}
 

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,59 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"no userinfo", "https://example.com/path?a=b", "https://example.com/path?a=b"},
+		{"username and password", "https://user-secret:pass-secret@example.com/p", "https://redacted@example.com/p"},
+		{"username only", "https://user-secret@example.com/p", "https://redacted@example.com/p"},
+		{"unparsable", "https://exa mple.com/\x7f", Value},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := URL(tt.raw)
+			if got != tt.want {
+				t.Errorf("URL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+			if strings.Contains(got, "secret") {
+				t.Errorf("URL(%q) leaked a credential: %q", tt.raw, got)
+			}
+		})
+	}
+}
+
+func TestHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"name and value", "Authorization: Bearer secret", "Authorization: " + Value},
+		{"no colon", "secret-without-colon", Value},
+		{"blank name", " : secret", ": " + Value},
+		{"empty value", "X-Empty:   ", "X-Empty:"},
+		{"multiple colons", "Cookie: a=1; b=secret:2", "Cookie: " + Value},
+		{"empty", "", Value},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Header(tt.header)
+			if got != tt.want {
+				t.Errorf("Header(%q) = %q, want %q", tt.header, got, tt.want)
+			}
+			if strings.Contains(got, "secret") {
+				t.Errorf("Header(%q) leaked a value: %q", tt.header, got)
+			}
+		})
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -19,6 +19,8 @@ func TestURL(t *testing.T) {
 		{"schemeless with username", "user-secret@example.com/p", Value},
 		{"at sign in path", "https://example.com/@handle", "https://example.com/@handle"},
 		{"ipv6 host", "https://user-secret:pass-secret@[::1]:8080/p", "https://redacted@[::1]:8080/p"},
+		{"multiple at signs", "https://user-secret:pass-secret@evil.example@example.com/p", "https://redacted@example.com/p"},
+		{"at sign in path with host", "https://example.com/a@b/c", "https://example.com/a@b/c"},
 		{"password only", "https://:pass-secret@example.com/", "https://redacted@example.com/"},
 		{"relative path", "/local/path", "/local/path"},
 		{"empty", "", ""},


### PR DESCRIPTION
## Description

`--show-config` marshalled the runtime `CrawlConfig` directly, so every secret the loader had already resolved was printed verbatim: basic-auth usernames and passwords, bearer tokens, API-key values, and custom header values including the ones expanded from `LT_HEADER_*`. That output routinely lands in shell history, CI logs, and redirected files.

This builds a redacted view for the diagnostic path instead of printing the live configuration:

- `redactConfigForDisplay` copies the auth sub-structs and the config string slices, then replaces the secret-bearing fields with the fixed `<redacted>` marker. The crawler still receives the real values at runtime.
- Provenance stays readable — `*_env` names, the API-key header name, and header names survive, because they say where a secret comes from rather than what it is.
- Redaction happens **before** validation. Validation messages quote the offending value, so an invalid header would otherwise carry its own value onto stderr; `Validate()` now runs against the redacted copy and both streams stay clean.
- Seed-URL userinfo is stripped for the same reason. The URL policy rejects such seeds at startup, but the configured value is still present at `--show-config` time.
- The output is routed through the command's out/err streams so the behavior is testable.

Fixes #90.

### Second commit: the startup banner

Review of the first commit surfaced the same disclosure on the path that runs by default. The banner printed before every crawl wrote the resolved basic-auth username to stdout, under a comment claiming it displayed auth status "without exposing credentials" — and the username is resolved from `username_env` exactly like the password. It also reported `Authentication: None` for bearer and API-key runs while sending the credential anyway.

`describeAuthForDisplay` now reports the credential kind and nothing of the credential itself. This is just outside the wording of #90, whose acceptance criteria name `--show-config` only; it is included because it is the same disclosure with the same root cause, and leaving it would contradict the changelog entry this PR adds.

### Third commit: errors and logs

A zero-based review of the whole PR by both review seats independently found the same P1, on two paths — and one seat reproduced it by running the binary. Three sites echoed their input back to the operator, all of them without `--show-config`:

```
invalid header format 'Authorization: Bearer REAL' ...   # internal/config, reaches stderr
invalid seed URL "https://user:pass@example.com/" ...    # internal/crawler, reaches stderr
level=WARN msg="Skipping invalid header format" header="X-Key: REAL"
```

Redacting the configuration dump while the rejection message carried the same value in full only moved the leak to the error branch. The redaction rules now live in `internal/redact`, shared by the diagnostic dump, the validation errors, and the logs — `config`, `crawler`, and `cmd` cannot import each other's unexported helpers, and duplicating the rules per call site is how these paths came to disagree in the first place.

Errors still identify what was rejected: the header keeps its name, and the seed URL keeps everything but its userinfo.

### Fourth and fifth commits: the redaction helper itself

The review of the third commit found that `redact.URL` had the same shape it was written to fix. It stripped userinfo only when `url.Parse` reported it and returned everything else unchanged — and `user:pass@example.com/path` parses as an *opaque* URL (scheme `user`, no userinfo), so it passed through with the password intact into the very message the third commit was meant to make safe. A schemeless seed is an ordinary typo, and those messages quote exactly the seeds that failed to parse. Confirmed by running the helper before fixing it.

A missing authority is now treated as unanalyzable: input carrying `@` with no host is replaced whole rather than guessed at. A URL with a host is unaffected, so `https://example.com/@handle` keeps its path.

Two smaller review points came with it. A header with no usable name redacts to a marker that says nothing about *which* configured header was rejected, so validation errors now carry a 1-based position (`invalid header 2 '<redacted>': ...`) — and the fifth commit documents that the position counts the header list after `LT_HEADER_*` is merged in. The leak test's third case asserted against a secret its input could not contain; it is now a forbidden header carrying one.

### Known limitation

The redaction list is explicit, not deny-by-default — #90's proposed change asks for deny-by-default "where practical", and this PR does not deliver it. A future secret-bearing config field has to be added to `redactConfigForDisplay` to stay out of the dump, and nothing fails if it is forgotten. #96 tracks a build-time guard for that; both review seats agreed it belongs there rather than here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Testing

- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Run locally against this branch:

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -race ./...` — pass (all packages)
- `gofmt -l .` — clean
- `git diff --check` — clean

New regression tests in `internal/cmd/root_test.go`:

- `TestShowCurrentConfigRedactsSecrets` — every auth variant (basic, bearer, API key) with both direct and `*_env` values, `LT_HEADER_Authorization` / `LT_HEADER_Cookie` / a custom `LT_HEADER_*`, a direct header, a malformed header, and a seed URL carrying userinfo. Asserts no secret reaches stdout or stderr, that the useful metadata is still shown, and that the runtime config is left unmutated.
- `TestShowCurrentConfigRedactsInvalidHeaderValidationError` — drives the validation-error path itself (single auth type so `validateHeaders` is actually reached) and asserts the warning on stderr carries the marker instead of the header value.
- `TestDescribeAuthForDisplayHidesCredentials` — no auth, basic with an env-resolved password, bearer from env, and API key from env. Asserts the exact banner text and that no resolved value appears in it.
- `internal/redact/redact_test.go` — URL with and without userinfo, username-only userinfo, an unparsable URL, and headers with no colon / a blank name / an empty value / multiple colons.
- `TestValidateHeadersDoesNotLeakHeaderValues` and `TestValidateExplicitURLsDoesNotLeakUserinfo` — the two error paths the review found, asserting the message identifies the offending item without quoting the secret.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

`docs/configuration.md` now states that `--show-config` displays the configuration with secret values redacted, and the `Unreleased` section of `CHANGELOG.md` records the change under `Security`.

## Additional Notes

Reviewed independently by two review seats across four rounds, the third of them a zero-based review of the whole PR. Three P1s were raised and all three are fixed here: the startup-banner disclosure (second commit), the error/log disclosure (third), and the opaque-URL hole in the redaction helper (fourth). Earlier P2 items — validation-path test coverage, shared slice backing arrays, seed-URL userinfo, error identifiability, a vacuous assertion — are folded into the commits above. The final round returned no P0/P1 from either seat.

Deliberately left out of scope and filed as follow-ups rather than left as silent gaps:

- #94 — credentials embedded in a seed URL's query string (`?api_key=…`) or in `include_patterns` / `exclude_patterns` are still shown. Unlike userinfo, those forms survive the URL policy, so they need their own decision about what a pattern may contain.
- #95 — `internal/cmd/root.go` still mixes `fmt.Printf`, `os.Stderr`, and the command's streams. Only `showCurrentConfig` was converted, because that is what the tests here need. `describeAuthForDisplay` is therefore tested directly rather than through the banner line.

`golangci-lint` v2.12.2 (the version CI resolves) was run locally against this branch: 0 issues.

The leaks were verified by unit test at the function boundary rather than by running the CLI end to end; #95 covers closing that gap.
