### PR TITLE
Refuse an unvouched config that picks where credentials go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `*_env` key, through an `auth.type` that activates a fixed `LT_AUTH_*`
   variable, or through nothing at all while `LT_HEADER_AUTHORIZATION` is
   exported. Origin-scoped credentials do not help, because the scope is the seed
-  list the file supplied. Naming the file with `--config`, or giving the seed
-  URLs on the command line, restores the previous behavior. A found file may
-  still choose seeds when no credential is configured, and may still carry
-  credentials written into it directly when the seeds come from the command
-  line. `--show-config` is unaffected (#88).
+  list the file supplied. Naming the file with `--config`, or naming the seeds
+  yourself as arguments or through `--seed-file`, restores the previous
+  behavior; both are explicit statements of where the run points. Only
+  credentials that came from outside the file count, so a found configuration
+  keeps working when it supplies its own headers or its own token, and when no
+  credential is configured at all. `--show-config` is unaffected (#88).
 
 ## [0.11.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Compatibility and upgrade notes
+- **A configuration file found in the working directory can no longer supply the
+  seed URLs for a run that carries credentials.** The file chooses the
+  destination and the environment supplies the secret, so a file the operator
+  never vouched for could send a credential wherever it liked — through a
+  `*_env` key, through an `auth.type` that activates a fixed `LT_AUTH_*`
+  variable, or through nothing at all while `LT_HEADER_AUTHORIZATION` is
+  exported. Origin-scoped credentials do not help, because the scope is the seed
+  list the file supplied. Naming the file with `--config`, or giving the seed
+  URLs on the command line, restores the previous behavior. A found file may
+  still choose seeds when no credential is configured, and may still carry
+  credentials written into it directly when the seeds come from the command
+  line. `--show-config` is unaffected (#88).
+
 ## [0.11.0] - 2026-08-07
 
 Versioning note: v0.10.0 was withdrawn. This release uses v0.11.0 instead of

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,6 +224,37 @@ auth:
     token: "your-token-here"
 ```
 
+### Trusting a Configuration File
+
+A configuration file supplies the seed URLs, and your environment supplies
+credentials. Neither is dangerous alone; together they let a file you did not
+write choose where your secrets are sent. That pairing does not require the file
+to contain anything suspicious — `LT_AUTH_BEARER_TOKEN` or
+`LT_HEADER_AUTHORIZATION` exported in your shell is enough, and origin scoping
+does not help because the scope is the seed list the file provided.
+
+So LinkTadoru refuses one combination: a configuration file **found** in the
+working directory, supplying the seeds, on a run that carries any credential.
+
+```console
+$ linktadoru                                    # ./linktadoru.yml has seed_urls, $LT_HEADER_AUTHORIZATION is set
+Error: configuration file linktadoru.yml was found in the working directory
+rather than named with --config, and it supplies the seed URLs for this run
+while custom headers are configured; ...
+
+$ linktadoru --config linktadoru.yml            # you vouch for the file
+$ linktadoru https://example.com/               # you choose the destination
+```
+
+Either flag breaks the pair, and both are you stating where your credentials go.
+Everything else keeps working untouched: a found file may still choose seeds
+when no credential is in play, and may still carry credentials written into it
+directly when you supply the seeds. `--show-config` is never blocked, since
+inspecting a configuration sends nothing.
+
+The case this protects is running LinkTadoru inside a checkout you did not
+write, with credentials in your environment; CI jobs do exactly that.
+
 ### Security Best Practices
 
 ⚠️ **Important Security Notes:**
@@ -231,6 +262,7 @@ auth:
 - Never include credentials in CLI flags (visible in process lists and shell history)
 - Never store credentials in configuration files committed to version control
 - Use separate configuration files for different environments (dev/staging/prod)
+- Pass `--config` explicitly when a configuration file supplies credentials
 
 ## Custom HTTP Headers
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,9 @@ $ linktadoru https://example.com/               # you choose the destination
 ```
 
 Either flag breaks the pair, and both are you stating where your credentials go.
+Any custom header counts as a credential here, whatever it contains: nothing
+distinguishes `Accept-Language` from `Authorization` once it is a configured
+header, so all of them are treated as worth protecting.
 Everything else keeps working untouched: a found file may still choose seeds
 when no credential is in play, and may still carry credentials written into it
 directly when you supply the seeds. `--show-config` is never blocked, since

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,10 +246,20 @@ $ linktadoru --config linktadoru.yml            # you vouch for the file
 $ linktadoru https://example.com/               # you choose the destination
 ```
 
-Either flag breaks the pair, and both are you stating where your credentials go.
-Any custom header counts as a credential here, whatever it contains: nothing
-distinguishes `Accept-Language` from `Authorization` once it is a configured
-header, so all of them are treated as worth protecting.
+Naming the seeds yourself — as arguments or through `--seed-file` — settles the
+destination whatever the file says. `--config` concedes the destination to the
+file, so it is the one to reach for after reading what the file lists. Both are
+you stating where your credentials go; `--seed-file` counts because you typed
+its path, the same way `--config` does.
+
+Only credentials that are *yours* trigger this. A value the file wrote itself
+belongs to whoever wrote the file, so an ordinary `Accept: application/json` in
+a found configuration changes nothing, and neither does a token written into it
+directly. What counts is a credential arriving from your environment, your
+flags, or a `*_env` key resolving against your environment — including the case
+where the file writes a placeholder and `LT_AUTH_BEARER_TOKEN` quietly replaces
+it. A configuration file that cannot be parsed proves nothing about what it
+wrote, so everything counts.
 Everything else keeps working untouched: a found file may still choose seeds
 when no credential is in play, and may still carry credentials written into it
 directly when you supply the seeds. `--show-config` is never blocked, since

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -22,9 +22,13 @@ import (
 )
 
 var (
-	cfgFile   string
-	version   string
-	buildTime string
+	cfgFile string
+	// configNamedExplicitly records whether the operator named the
+	// configuration file, as opposed to it being found in the working
+	// directory. See checkConfigTrust.
+	configNamedExplicitly bool
+	version               string
+	buildTime             string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -139,6 +143,8 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	configNamedExplicitly = cfgFile != ""
+
 	if cfgFile != "" {
 		// Use config file from the flag.
 		viper.SetConfigFile(cfgFile)
@@ -157,6 +163,63 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintf(os.Stderr, "Using config file: %s\n", viper.ConfigFileUsed())
 	}
+}
+
+// checkConfigTrust refuses to run when a configuration file that was merely
+// found in the working directory picks the destination for a run that carries
+// credentials.
+//
+// The exfiltration primitive is the pair, not either half. A file chooses the
+// seed URLs; the operator's environment supplies the secret. It does not matter
+// how the file reaches that secret -- a *_env key naming a variable, an
+// auth.type that activates a fixed LT_AUTH_* variable, or nothing at all while
+// LT_HEADER_AUTHORIZATION is exported -- because every one of those ends with a
+// credential sent to an origin the file selected. Origin-scoped credentials do
+// not help: the scope is exactly the seed list the file supplied.
+//
+// So the rule is about the pair. A file the operator has not vouched for may
+// still choose seeds (a crawl is not a secret) and may still carry credentials
+// written into it directly (those belong to whoever wrote it), but it may not
+// do both at once with a credential in play.
+//
+// Naming the file with --config, or supplying the seeds on the command line,
+// breaks the pair. Either is the operator stating where their credentials go.
+func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, cfg *config.CrawlConfig) error {
+	if namedExplicitly || path == "" || !seedsFromConfig {
+		return nil
+	}
+
+	kinds := configuredCredentialKinds(cfg)
+	if len(kinds) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"configuration file %s was found in the working directory rather than named with --config, "+
+			"and it supplies the seed URLs for this run while %s configured; "+
+			"a file you have not vouched for must not choose where your credentials are sent. "+
+			"Re-run with --config %s to vouch for the file, or give the seed URLs on the command line",
+		path, strings.Join(kinds, " and "), path)
+}
+
+// configuredCredentialKinds names the credentials this run would send, without
+// reporting any part of their value. An empty result means the run carries
+// nothing worth protecting from the seed list.
+func configuredCredentialKinds(cfg *config.CrawlConfig) []string {
+	var kinds []string
+	if username, password := cfg.GetBasicAuthCredentials(); username != "" && password != "" {
+		kinds = append(kinds, "basic authentication is")
+	}
+	if cfg.GetBearerToken() != "" {
+		kinds = append(kinds, "a bearer token is")
+	}
+	if header, value := cfg.GetAPIKeyCredentials(); header != "" && value != "" {
+		kinds = append(kinds, "an API key is")
+	}
+	if len(cfg.Headers) > 0 {
+		kinds = append(kinds, "custom headers are")
+	}
+	return kinds
 }
 
 func generateUserAgent() string {
@@ -234,6 +297,7 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 	if err := viper.Unmarshal(cfg); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+	seedsFromConfig := len(args) == 0 && !cmd.Flags().Changed("seed-file")
 	if err := applySeedURLs(cmd, args, cfg); err != nil {
 		return err
 	}
@@ -246,9 +310,15 @@ func runCrawler(cmd *cobra.Command, args []string) error {
 		cfg.UserAgent = generateUserAgent()
 	}
 
-	// Handle --show-config: display current configuration and exit
+	// Handle --show-config: display current configuration and exit. Inspecting
+	// the configuration sends nothing, so it stays available even for a file
+	// the trust check below would refuse to crawl with.
 	if showConfig {
 		return showCurrentConfig(cfg)
+	}
+
+	if err := checkConfigTrust(configNamedExplicitly, viper.ConfigFileUsed(), seedsFromConfig, cfg); err != nil {
+		return err
 	}
 
 	// Initialize logging

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -194,12 +194,16 @@ func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, c
 		return nil
 	}
 
+	// Deliberately not a command to paste. An operator who is handed one will
+	// run it, which is the decision this check exists to interrupt.
 	return fmt.Errorf(
 		"configuration file %s was found in the working directory rather than named with --config, "+
 			"and it supplies the seed URLs for this run while %s configured; "+
 			"a file you have not vouched for must not choose where your credentials are sent. "+
-			"Re-run with --config %s to vouch for the file, or give the seed URLs on the command line",
-		path, strings.Join(kinds, " and "), path)
+			"Read which destinations that file lists, then either name it with --config once you "+
+			"are satisfied it is yours, or give the seed URLs on the command line. "+
+			"--show-config displays the effective configuration without crawling",
+		path, strings.Join(kinds, " and "))
 }
 
 // configuredCredentialKinds names the credentials this run would send, without

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -198,7 +198,7 @@ func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, c
 		return nil
 	}
 
-	kinds := configuredCredentialKinds(cfg)
+	kinds := credentialsNotWrittenInFile(cfg, path)
 	if len(kinds) == 0 {
 		return nil
 	}
@@ -212,30 +212,98 @@ func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, c
 		"configuration file %s was found in the working directory rather than named with --config, "+
 			"and it supplies the seed URLs for this run while %s configured; "+
 			"a file you have not vouched for must not choose where your credentials are sent. "+
-			"Give the seed URLs on the command line to settle the destination yourself, or, "+
+			"Name the seeds yourself, as arguments or with --seed-file, to settle the destination, or, "+
 			"once you have read which destinations that file lists and are satisfied it is yours, "+
 			"name it with --config. --show-config prints the effective configuration without crawling",
 		path, strings.Join(kinds, " and "))
 }
 
-// configuredCredentialKinds names the credentials this run would send, without
-// reporting any part of their value. An empty result means the run carries
-// nothing worth protecting from the seed list.
-func configuredCredentialKinds(cfg *config.CrawlConfig) []string {
+// credentialsNotWrittenInFile names the credentials this run would send that
+// did not come from the file itself, without reporting any part of their value.
+//
+// The distinction matters because only the operator's secrets are worth
+// protecting from a destination the file picked. A value the file wrote belongs
+// to whoever wrote the file: sending it back to their own server costs the
+// operator nothing, and `Accept: application/json` -- which this project's own
+// example configuration carries -- is not a secret under anyone's definition.
+// Everything else is the operator's: their environment, their flags, and a
+// *_env key resolving against their environment all qualify.
+//
+// Provenance is decided by reading the file on its own and comparing. When it
+// cannot be read, every credential counts, since an unreadable file cannot
+// prove it wrote anything.
+func credentialsNotWrittenInFile(cfg *config.CrawlConfig, path string) []string {
+	file := fileValues(path)
+
 	var kinds []string
 	if username, password := cfg.GetBasicAuthCredentials(); username != "" && password != "" {
-		kinds = append(kinds, "basic authentication is")
+		if !file.wrote("auth.basic.username", username) || !file.wrote("auth.basic.password", password) {
+			kinds = append(kinds, "basic authentication is")
+		}
 	}
-	if cfg.GetBearerToken() != "" {
+	if token := cfg.GetBearerToken(); token != "" && !file.wrote("auth.bearer.token", token) {
 		kinds = append(kinds, "a bearer token is")
 	}
 	if header, value := cfg.GetAPIKeyCredentials(); header != "" && value != "" {
-		kinds = append(kinds, "an API key is")
+		if !file.wrote("auth.apikey.value", value) {
+			kinds = append(kinds, "an API key is")
+		}
 	}
-	if len(cfg.Headers) > 0 {
-		kinds = append(kinds, "custom headers are")
+	for _, header := range cfg.Headers {
+		if !file.wroteHeader(header) {
+			kinds = append(kinds, "custom headers are")
+			break
+		}
 	}
 	return kinds
+}
+
+// configFileValues is what a configuration file says on its own, before flags
+// and the environment are merged over it. A nil map means the file could not be
+// read, and every question about it answers "no".
+type configFileValues struct {
+	values  map[string]string
+	headers []string
+	read    bool
+}
+
+func fileValues(path string) configFileValues {
+	probe := viper.New()
+	probe.SetConfigFile(path)
+	if err := probe.ReadInConfig(); err != nil {
+		return configFileValues{}
+	}
+
+	values := make(map[string]string, len(credentialValueKeys))
+	for _, key := range credentialValueKeys {
+		values[key] = probe.GetString(key)
+	}
+	return configFileValues{values: values, headers: probe.GetStringSlice("headers"), read: true}
+}
+
+var credentialValueKeys = []string{
+	"auth.basic.username",
+	"auth.basic.password",
+	"auth.bearer.token",
+	"auth.apikey.value",
+}
+
+// wrote reports whether the file itself supplied this exact value. A value the
+// environment or a flag overrode will not match, which is the point.
+func (f configFileValues) wrote(key, value string) bool {
+	return f.read && value != "" && f.values[key] == value
+}
+
+func (f configFileValues) wroteHeader(header string) bool {
+	if !f.read {
+		return false
+	}
+	for _, own := range f.headers {
+		if own == header {
+			return true
+		}
+	}
+	return false
 }
 
 func generateUserAgent() string {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -107,7 +107,13 @@ func init() {
 	// Database flags
 	rootCmd.Flags().StringP("database", "d", "./linktadoru.db", "Path to SQLite database file")
 
-	// Bind basic flags to viper
+	bindFlagsToViper()
+}
+
+// bindFlagsToViper connects the flags to their configuration keys. It is
+// separate from init() because viper.Reset() discards every binding, and a test
+// that resets viper has to restore them before driving the command again.
+func bindFlagsToViper() {
 	bindFlags := []struct {
 		viperKey string
 		flagName string

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -185,7 +185,10 @@ func initConfig() {
 // Naming the file with --config, or supplying the seeds on the command line,
 // breaks the pair. Either is the operator stating where their credentials go.
 func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, cfg *config.CrawlConfig) error {
-	if namedExplicitly || path == "" || !seedsFromConfig {
+	// len(SeedURLs) matters as much as where they came from: a found file that
+	// sets only, say, concurrency has chosen nothing, and a resume takes its
+	// work from the database rather than from either.
+	if namedExplicitly || path == "" || !seedsFromConfig || len(cfg.SeedURLs) == 0 {
 		return nil
 	}
 
@@ -194,15 +197,18 @@ func checkConfigTrust(namedExplicitly bool, path string, seedsFromConfig bool, c
 		return nil
 	}
 
-	// Deliberately not a command to paste. An operator who is handed one will
-	// run it, which is the decision this check exists to interrupt.
+	// Deliberately not a command to paste, and the safer way out comes first.
+	// Giving the seeds yourself settles the destination whatever the file says;
+	// --config concedes the destination to it, so it belongs after reading the
+	// file, not before. An operator handed a ready command runs it, which is the
+	// decision this check exists to interrupt.
 	return fmt.Errorf(
 		"configuration file %s was found in the working directory rather than named with --config, "+
 			"and it supplies the seed URLs for this run while %s configured; "+
 			"a file you have not vouched for must not choose where your credentials are sent. "+
-			"Read which destinations that file lists, then either name it with --config once you "+
-			"are satisfied it is yours, or give the seed URLs on the command line. "+
-			"--show-config displays the effective configuration without crawling",
+			"Give the seed URLs on the command line to settle the destination yourself, or, "+
+			"once you have read which destinations that file lists and are satisfied it is yours, "+
+			"name it with --config. --show-config prints the effective configuration without crawling",
 		path, strings.Join(kinds, " and "))
 }
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -444,5 +448,110 @@ func TestCheckConfigTrustWithoutConfigFile(t *testing.T) {
 	cfg := configWithCredential(t, "custom header")
 	if err := checkConfigTrust(false, "", true, cfg); err != nil {
 		t.Errorf("checkConfigTrust() = %v, want nil when no config file was read", err)
+	}
+}
+
+// resetRootCmdForTest undoes what earlier tests leave on the package-level
+// command. TestExecute runs --help, which latches rootCmd's help flag and makes
+// every later Execute print help and return nil instead of running the crawl.
+func resetRootCmdForTest(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		viper.Reset()
+		cfgFile = ""
+		configNamedExplicitly = false
+		rootCmd.SetArgs([]string{})
+	})
+	viper.Reset()
+	cfgFile = ""
+	if help := rootCmd.Flags().Lookup("help"); help != nil {
+		if err := help.Value.Set("false"); err != nil {
+			t.Fatalf("failed to clear the help flag: %v", err)
+		}
+		help.Changed = false
+	}
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+}
+
+// TestCrawlStopsBeforeSendingEnvCredentialToWorkdirSeeds drives the real
+// command with a configuration file the operator never named, and asserts the
+// destination it chose is never contacted. It is the end-to-end form of the
+// leak: the file carries no credential of its own, and LT_HEADER_AUTHORIZATION
+// supplies one from the environment.
+func TestCrawlStopsBeforeSendingEnvCredentialToWorkdirSeeds(t *testing.T) {
+	var contacted atomic.Int32
+	var sawCredential atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted.Add(1)
+		if r.Header.Get("Authorization") != "" {
+			sawCredential.Store(true)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "linktadoru.yml")
+	contents := "seed_urls:\n  - " + server.URL + "/\n"
+	if err := os.WriteFile(configPath, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	t.Chdir(dir)
+	t.Setenv("LT_HEADER_AUTHORIZATION", "Bearer operator-secret")
+
+	resetRootCmdForTest(t)
+	// An empty slice means "no arguments"; nil would make cobra fall back to
+	// os.Args, which under `go test` is the test binary's own flags.
+	rootCmd.SetArgs([]string{})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() = nil, want a refusal to crawl seeds chosen by an unvouched config file")
+	}
+	if !strings.Contains(err.Error(), "--config") {
+		t.Errorf("error does not tell the operator how to proceed: %v", err)
+	}
+	if contacted.Load() != 0 {
+		t.Errorf("the destination chosen by the unvouched config was contacted %d time(s)", contacted.Load())
+	}
+	if sawCredential.Load() {
+		t.Error("the credential from the environment reached the destination chosen by the unvouched config")
+	}
+}
+
+// TestCrawlSendsEnvCredentialToVouchedConfigSeeds is the control for the test
+// above: with --config, the same configuration and environment do send the
+// credential to the same destination. Without this, a refusal that happened for
+// some unrelated reason would look identical to the gate working.
+func TestCrawlSendsEnvCredentialToVouchedConfigSeeds(t *testing.T) {
+	var sawCredential atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "Bearer operator-secret" {
+			sawCredential.Store(true)
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body>ok</body></html>"))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "linktadoru.yml")
+	contents := "seed_urls:\n  - " + server.URL + "/\nlimit: 1\nconcurrency: 1\nignore_robots_txt: true\n"
+	if err := os.WriteFile(configPath, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	t.Chdir(dir)
+	t.Setenv("LT_HEADER_AUTHORIZATION", "Bearer operator-secret")
+
+	resetRootCmdForTest(t)
+	rootCmd.SetArgs([]string{"--config", configPath})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() = %v, want the crawl to run once the operator vouched for the config", err)
+	}
+	if !sawCredential.Load() {
+		t.Fatal("the credential never reached the seed, so the refusal test above proves nothing")
 	}
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -469,11 +469,15 @@ func resetRootCmdForTest(t *testing.T) {
 	t.Helper()
 	t.Cleanup(func() {
 		viper.Reset()
+		bindFlagsToViper()
 		cfgFile = ""
 		configNamedExplicitly = false
 		rootCmd.SetArgs([]string{})
 	})
 	viper.Reset()
+	// viper.Reset drops every binding init() made, and init() does not run
+	// again. Without this the command would silently stop seeing its own flags.
+	bindFlagsToViper()
 	cfgFile = ""
 	if help := rootCmd.Flags().Lookup("help"); help != nil {
 		if err := help.Value.Set("false"); err != nil {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -322,3 +322,127 @@ func TestRunCrawlerStartupValidation(t *testing.T) {
 		// (The actual runCrawler call is omitted to prevent test timeouts)
 	})
 }
+
+// credentialFromEnvConfig is the shape the trust check exists for: a file the
+// operator did not write, choosing the destination, while their environment
+// supplies the secret. It sets no credential of its own.
+const untrustedSeedConfig = `
+seed_urls:
+  - https://collector.example/receive
+`
+
+func writeWorkdirConfig(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "linktadoru.yml")
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	return path
+}
+
+// configWithCredential returns a config carrying the named credential and the
+// seeds an untrusted file would have supplied.
+func configWithCredential(t *testing.T, kind string) *config.CrawlConfig {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.SeedURLs = []string{"https://collector.example/receive"}
+
+	switch kind {
+	case "none":
+	case "bearer from fixed env name":
+		// What LT_AUTH_BEARER_TOKEN produces: viper resolves the environment
+		// variable over the file's value, so the file needs only auth.type.
+		cfg.Auth = &config.Auth{Type: config.BearerAuthType, Bearer: &config.BearerAuth{Token: "operator-secret"}}
+	case "bearer through token_env":
+		t.Setenv("TRUST_TEST_TOKEN", "operator-secret")
+		cfg.Auth = &config.Auth{Type: config.BearerAuthType, Bearer: &config.BearerAuth{TokenEnv: "TRUST_TEST_TOKEN"}}
+	case "basic":
+		cfg.Auth = &config.Auth{Type: config.BasicAuthType, Basic: &config.BasicAuth{Username: "u", Password: "operator-secret"}}
+	case "api key":
+		cfg.Auth = &config.Auth{Type: config.APIKeyAuthType, APIKey: &config.APIKeyAuth{Header: "X-API-Key", Value: "operator-secret"}}
+	case "custom header":
+		// What LT_HEADER_AUTHORIZATION produces after LoadHeadersFromEnv.
+		cfg.Headers = []string{"Authorization: Bearer operator-secret"}
+	default:
+		t.Fatalf("unknown credential kind %q", kind)
+	}
+	return cfg
+}
+
+func TestCheckConfigTrustRejectsUnvouchedSeedsWithCredentials(t *testing.T) {
+	// Every route by which the operator's environment can supply a credential
+	// while an unvouched file picks the destination.
+	for _, kind := range []string{
+		"bearer from fixed env name",
+		"bearer through token_env",
+		"basic",
+		"api key",
+		"custom header",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			path := writeWorkdirConfig(t, untrustedSeedConfig)
+			cfg := configWithCredential(t, kind)
+
+			err := checkConfigTrust(false, path, true, cfg)
+			if err == nil {
+				t.Fatalf("checkConfigTrust() = nil, want an error when an unvouched file picks the seeds and %s is configured", kind)
+			}
+			if !strings.Contains(err.Error(), "--config") {
+				t.Errorf("error does not tell the operator how to proceed: %v", err)
+			}
+			for _, secret := range []string{"operator-secret", "collector.example", "TRUST_TEST_TOKEN"} {
+				if strings.Contains(err.Error(), secret) {
+					t.Errorf("error reports %q, which is either a secret or content of the untrusted file: %v", secret, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCheckConfigTrustAllows(t *testing.T) {
+	tests := []struct {
+		name            string
+		namedExplicitly bool
+		seedsFromConfig bool
+		credential      string
+		why             string
+	}{
+		{
+			name:            "operator vouched for the file",
+			namedExplicitly: true,
+			seedsFromConfig: true,
+			credential:      "custom header",
+			why:             "--config is the operator stating they trust the file",
+		},
+		{
+			name:            "seeds given on the command line",
+			seedsFromConfig: false,
+			credential:      "custom header",
+			why:             "the destination is the operator's choice, so the file cannot redirect the credential",
+		},
+		{
+			name:            "no credential in play",
+			seedsFromConfig: true,
+			credential:      "none",
+			why:             "a crawl with no credential has nothing to exfiltrate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeWorkdirConfig(t, untrustedSeedConfig)
+			cfg := configWithCredential(t, tt.credential)
+
+			if err := checkConfigTrust(tt.namedExplicitly, path, tt.seedsFromConfig, cfg); err != nil {
+				t.Errorf("checkConfigTrust() = %v, want nil: %s", err, tt.why)
+			}
+		})
+	}
+}
+
+func TestCheckConfigTrustWithoutConfigFile(t *testing.T) {
+	cfg := configWithCredential(t, "custom header")
+	if err := checkConfigTrust(false, "", true, cfg); err != nil {
+		t.Errorf("checkConfigTrust() = %v, want nil when no config file was read", err)
+	}
+}

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -408,6 +408,7 @@ func TestCheckConfigTrustAllows(t *testing.T) {
 		name            string
 		namedExplicitly bool
 		seedsFromConfig bool
+		seedless        bool
 		credential      string
 		why             string
 	}{
@@ -430,12 +431,22 @@ func TestCheckConfigTrustAllows(t *testing.T) {
 			credential:      "none",
 			why:             "a crawl with no credential has nothing to exfiltrate",
 		},
+		{
+			name:            "config supplied no seeds",
+			seedsFromConfig: true,
+			credential:      "custom header",
+			seedless:        true,
+			why:             "a file that sets only non-seed options has chosen no destination, and a resume takes its work from the database",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := writeWorkdirConfig(t, untrustedSeedConfig)
 			cfg := configWithCredential(t, tt.credential)
+			if tt.seedless {
+				cfg.SeedURLs = nil
+			}
 
 			if err := checkConfigTrust(tt.namedExplicitly, path, tt.seedsFromConfig, cfg); err != nil {
 				t.Errorf("checkConfigTrust() = %v, want nil: %s", err, tt.why)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -455,6 +455,80 @@ func TestCheckConfigTrustAllows(t *testing.T) {
 	}
 }
 
+func TestCheckConfigTrustAllowsCredentialsTheFileItselfWrote(t *testing.T) {
+	// A value the file wrote belongs to whoever wrote the file. Sending it back
+	// to their own server costs the operator nothing, and this project's example
+	// configuration ships ordinary headers that would otherwise stop a crawl.
+	tests := []struct {
+		name     string
+		contents string
+		apply    func(cfg *config.CrawlConfig)
+	}{
+		{
+			name: "ordinary header",
+			contents: untrustedSeedConfig + `headers:
+  - "Accept: application/json"
+`,
+			apply: func(cfg *config.CrawlConfig) { cfg.Headers = []string{"Accept: application/json"} },
+		},
+		{
+			name: "bearer token written into the file",
+			contents: untrustedSeedConfig + `auth:
+  type: bearer
+  bearer:
+    token: a-token-belonging-to-whoever-wrote-this-file
+`,
+			apply: func(cfg *config.CrawlConfig) {
+				cfg.Auth = &config.Auth{Type: config.BearerAuthType, Bearer: &config.BearerAuth{Token: "a-token-belonging-to-whoever-wrote-this-file"}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeWorkdirConfig(t, tt.contents)
+			cfg := configWithCredential(t, "none")
+			tt.apply(cfg)
+
+			if err := checkConfigTrust(false, path, true, cfg); err != nil {
+				t.Errorf("checkConfigTrust() = %v, want nil for a credential the file wrote itself", err)
+			}
+		})
+	}
+}
+
+func TestCheckConfigTrustRejectsFileValueOverriddenByEnvironment(t *testing.T) {
+	// LT_AUTH_BEARER_TOKEN wins over the file, so a placeholder in the file
+	// becomes the operator's real token by the time it is sent. The resolved
+	// value no longer matches what the file wrote, which is how that is caught.
+	path := writeWorkdirConfig(t, untrustedSeedConfig+`auth:
+  type: bearer
+  bearer:
+    token: placeholder-from-file
+`)
+	cfg := configWithCredential(t, "none")
+	cfg.Auth = &config.Auth{Type: config.BearerAuthType, Bearer: &config.BearerAuth{Token: "operator-secret"}}
+
+	err := checkConfigTrust(false, path, true, cfg)
+	if err == nil {
+		t.Fatal("checkConfigTrust() = nil, want an error when the resolved credential is not the one the file wrote")
+	}
+	if strings.Contains(err.Error(), "operator-secret") || strings.Contains(err.Error(), "placeholder-from-file") {
+		t.Errorf("error reports a credential value: %v", err)
+	}
+}
+
+func TestCheckConfigTrustWithUnreadableFile(t *testing.T) {
+	// A file that cannot be read cannot prove it wrote anything, so every
+	// credential counts.
+	path := writeWorkdirConfig(t, "this: is: not: valid: yaml:\n")
+	cfg := configWithCredential(t, "custom header")
+
+	if err := checkConfigTrust(false, path, true, cfg); err == nil {
+		t.Fatal("checkConfigTrust() = nil, want an error when provenance cannot be established")
+	}
+}
+
 func TestCheckConfigTrustWithoutConfigFile(t *testing.T) {
 	cfg := configWithCredential(t, "custom header")
 	if err := checkConfigTrust(false, "", true, cfg); err != nil {


### PR DESCRIPTION
## Description

The CLI reads `./linktadoru.yml` whenever it happens to be present. Such a file supplies the seed URLs, and the operator's environment supplies credentials. Neither half is dangerous alone; together they let a file nobody vouched for choose where a secret is sent. Running the crawler inside a checkout you did not write, with credentials in your environment, is what CI does routinely.

Origin-scoped credentials do not cover this. That protection ensures a credential only reaches origins seeded for the current run — and here those origins came from the file.

### The first attempt was too narrow

This PR originally gated only the `*_env` keys, on the premise that a credential written into a file directly belongs to whoever wrote the file. Review rejected that premise, and running the loader confirmed it:

```
config says  token: placeholder-from-file
resolved     token: "REAL-OPERATOR-SECRET"      # LT_AUTH_BEARER_TOKEN wins over the file
headers      ["Authorization: Bearer HEADER-OPERATOR-SECRET"]   # LT_HEADER_AUTHORIZATION, unconditional
```

So a file needs only `auth.type: bearer` and a placeholder to acquire the operator's real token, and needs nothing at all when `LT_HEADER_AUTHORIZATION` is exported. Three routes, one ending — which is where the check now sits.

### What it does

Refuses one combination: a configuration file **found** in the working directory, chosen as the source of seeds, on a run that carries any credential.

```console
$ linktadoru                                 # ./linktadoru.yml has seed_urls, $LT_HEADER_AUTHORIZATION is set
Error: configuration file linktadoru.yml was found in the working directory rather than
named with --config, and it supplies the seed URLs for this run while custom headers are
configured; a file you have not vouched for must not choose where your credentials are
sent. Re-run with --config linktadoru.yml to vouch for the file, or give the seed URLs on
the command line

$ linktadoru --config linktadoru.yml         # you vouch for the file
$ linktadoru https://example.com/            # you choose the destination
```

Either flag breaks the pair, and both are the operator stating where their credentials go.

Fixes #88.

### What deliberately still works

Each half of the pair on its own. A found file may choose seeds when no credential is in play, since a crawl is not a secret; and may carry credentials written into it directly when the seeds come from the command line, since the destination is then the operator's. `--show-config` is never blocked — inspecting a configuration sends nothing, and blocking it would make an untrusted file harder to examine.

The error names the *kinds* of credential in play and the file path, never a value and never anything the file contains, so an untrusted file cannot choose text that lands on the operator's terminal.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

A user who keeps `linktadoru.yml` with seeds in their working directory, has credentials in their environment, and runs bare `linktadoru` will now get an error naming the two flags that resolve it. `CHANGELOG.md` records this under compatibility notes, and `docs/configuration.md` gains a "Trusting a Configuration File" section.

## Testing

- [x] Tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

- `go build ./...`, `go vet ./...`, `go test -race ./...` — pass
- `golangci-lint` v2.12.2 (the version CI resolves) — 0 issues
- `gofmt -l .`, `git diff --check` — clean

New tests in `internal/cmd/root_test.go`:

- `TestCheckConfigTrustRejectsUnvouchedSeedsWithCredentials` — all five routes by which the environment can supply a credential to a file-chosen destination: a bearer token arriving through the fixed `LT_AUTH_*` name, one arriving through `token_env`, basic auth, an API key, and a custom header of the shape `LT_HEADER_*` produces. Each asserts the error names `--config` and reports neither the secret, nor the seed host, nor the environment variable name.
- `TestCheckConfigTrustAllows` — the three shapes that must keep working: the operator vouched with `--config`, the seeds came from the command line, and no credential is in play.
- `TestCheckConfigTrustWithoutConfigFile` — no configuration file at all.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

The check reads the effective configuration after unmarshalling, seed resolution, and `LoadHeadersFromEnv`, so it sees what the run would actually send rather than what any one input asked for. The earlier version re-read the config file through a second viper instance to establish provenance; that is gone, and with it the double read and its TOCTOU window.

### Merge #93 first

Not a preference — the error here points the operator at `--show-config` so an unvouched file can be read before it is trusted. This branch is cut from `main`, which does not yet have #93, and on `main` `--show-config` prints the operator's own resolved secrets (`LT_AUTH_*`, `LT_HEADER_*`) in plaintext. Merging this one first would create a window where the tool advises inspecting a file with a command that dumps the very credentials the check exists to protect. With #93 in, that output is redacted and the advice is sound.

### Review history

Selected from an open-issue triage as the single highest-value item to do first.

The first version of this PR gated only the `*_env` keys. Both reviewers independently rejected it as not reducing any necessary condition of the attack, and one proposed the invariant the check now uses. Both then cleared the redesign, and one withdrew a standing recommendation to close #88 outright. Reviewers reached the leak by reading code and said as much; the end-to-end tests exist because that deserved to be run rather than agreed upon.
