### PR TITLE
Remove follow_external_hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-08-10
+
+### Removed
+- **Remove `follow_external_hosts` for v0.12.0.** The old
+  `--follow-external-hosts` flag is rejected as an unknown flag. The old YAML
+  key and `LT_FOLLOW_EXTERNAL_HOSTS` environment variable are ignored and have
+  no effect. Add trusted cross-origin ranges explicitly with
+  `include_patterns`, for example: `^https://trusted\.example(?:/.*)?$`.
+- Existing databases may mark pending URLs outside the current URL policy as
+  skipped. Re-add such URLs as explicit seeds if they need to be crawled.
+
 ## [0.11.0] - 2026-08-07
 
 Versioning note: v0.10.0 was withdrawn. This release uses v0.11.0 instead of

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@ Go言語で構築された高性能Webクローラーおよびリンク解析ツ
 - **複数の認証方式**: Basic認証、Bearerトークン、APIキーに対応
 - **カスタムHTTPヘッダー**: リクエスト用カスタムヘッダーの設定
 - **Robots.txt準拠**: robots.txtルールとクロール遅延を尊重
-- **安全なデフォルト**: シードホスト内に留まり（`follow_external_hosts: false`）、レスポンスボディを10 MiBに制限（`max_response_size`）
+- **安全なデフォルト**: `include_patterns`で絶対URL範囲を追加しない限りシードorigin内に留まり、レスポンスボディを10 MiBに制限（`max_response_size`）
 - **SQLiteストレージ**: クエリ可能なSQLiteデータベースに全データを保存
 - **再開可能**: 中断されたセッション用の永続キュー
 - **柔軟な設定**: CLIフラグ、環境変数、または階層設定ファイル対応

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A high-performance web crawler and link analysis tool built in Go.
 - **Multiple Authentication Methods**: Support for Basic Auth, Bearer tokens, and API keys
 - **Custom HTTP Headers**: Set custom headers for requests
 - **Robots.txt Compliance**: Respects robots.txt rules and crawl delays
-- **Safe by Default**: Stays on the seed hosts (`follow_external_hosts: false`) and caps response bodies at 10 MiB (`max_response_size`)
+- **Safe by Default**: Stays on the seed origins unless an absolute URL range is added with `include_patterns`, and caps response bodies at 10 MiB (`max_response_size`)
 - **SQLite Storage**: All data stored in a queryable SQLite database
 - **Resumable**: Persistent queue for interrupted sessions
 - **Flexible Configuration**: CLI flags, environment variables, or config file with hierarchical support

--- a/docs/basic-usage.ja.md
+++ b/docs/basic-usage.ja.md
@@ -105,9 +105,6 @@ exclude_patterns:
 `https://hogehoge.com/search/items?q=go`を許可し、
 `https://hogehoge.com/account`と`/ika/`を含むURLを拒否します。
 includeだけで許可されたoriginへは、認証情報や設定済みcustom headerを送りません。
-`^https?://.*$`のような広いincludeは、`follow_external_hosts: true`と同じ到達リスクを
-持ちます。`follow_external_hosts: true`の場合、`include_patterns`では許可範囲を
-狭められません。制限には`exclude_patterns`を使用してください。
 
 ## 高度な使用例
 
@@ -118,7 +115,6 @@ includeだけで許可されたoriginへは、認証情報や設定済みcustom 
 ```bash
 ./linktadoru \
   --limit 100 \
-  --include-patterns "^https?://[^/]*(site1|site2)\.com/.*" \
   https://site1.com \
   https://site2.com
 ```

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -85,7 +85,6 @@ Crawl multiple related sites:
 ```bash
 ./linktadoru \
   --limit 100 \
-  --include-patterns "^https?://[^/]*(site1|site2)\.com/.*" \
   https://site1.com \
   https://site2.com
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,6 @@ This table is the authoritative reference for all options. Run `./linktadoru --h
 | request_timeout | `-t, --timeout` | `LT_REQUEST_TIMEOUT` | 30s | HTTP request timeout (Go duration) |
 | user_agent | `-u, --user-agent` | `LT_USER_AGENT` | LinkTadoru/1.0 | HTTP User-Agent header |
 | ignore_robots_txt | `--ignore-robots-txt` | `LT_IGNORE_ROBOTS_TXT` | false | Ignore robots.txt rules |
-| follow_external_hosts | `--follow-external-hosts` | `LT_FOLLOW_EXTERNAL_HOSTS` | false | Compatibility switch allowing every URL with an allowed scheme; includes do not narrow it and excludes still win |
 | limit | `-l, --limit` | `LT_LIMIT` | 0 | Maximum pages to crawl (0=unlimited) |
 | max_depth | `--max-depth` | `LT_MAX_DEPTH` | 0 | Maximum first-discovery depth; 0=unlimited, seeds=0 |
 | max_response_size | `--max-response-size` | `LT_MAX_RESPONSE_SIZE` | 10485760 | Max response body size in bytes (10 MiB) |
@@ -58,7 +57,6 @@ request_delay: 0.1           # Delay between requests in seconds (number)
 request_timeout: "30s"       # HTTP request timeout (Go duration, e.g. "30s", "1m")
 user_agent: "LinkTadoru/1.0"
 ignore_robots_txt: false
-follow_external_hosts: false # Stay on the seed hosts by default
 limit: 0                     # Stop after N pages (0 = unlimited)
 max_depth: 0                 # 0 = unlimited; positive N includes depth N
 max_response_size: 10485760  # Max response body size in bytes (10 MiB)
@@ -123,14 +121,7 @@ This allows `https://example.com/news/1` and
 `https://hogehoge.com/search/items?q=go`, but not
 `https://hogehoge.com/account` or an otherwise allowed URL containing
 `/ika/`. An include-only origin never receives authentication or configured
-custom headers. A broad include such as `^https?://.*$` has the same reach risk
-as `follow_external_hosts: true`. When `follow_external_hosts` is true,
-`include_patterns` do not narrow its allow-all scope; use `exclude_patterns` to
-restrict it.
-
-Before this change, includes narrowed an already host-limited set. Existing
-absolute cross-origin includes now actively add that range. Rewrite relative
-includes as absolute patterns (and/or excludes) before upgrading.
+custom headers.
 
 ## Environment Variables
 

--- a/docs/technical-specification.ja.md
+++ b/docs/technical-specification.ja.md
@@ -59,8 +59,8 @@ type CrawlConfig struct {
     RequestTimeout      time.Duration
     UserAgent           string
     IgnoreRobotsTxt     bool
-    FollowExternalHosts bool
     Limit               int
+    MaxDepth            int           // 0 = 無制限
     MaxResponseSize     int64         // バイト
     Auth                *Auth
     IncludePatterns     []string

--- a/docs/technical-specification.md
+++ b/docs/technical-specification.md
@@ -59,8 +59,8 @@ type CrawlConfig struct {
     RequestTimeout      time.Duration
     UserAgent           string
     IgnoreRobotsTxt     bool
-    FollowExternalHosts bool
     Limit               int
+    MaxDepth            int           // 0 = unlimited
     MaxResponseSize     int64         // bytes
     Auth                *Auth
     IncludePatterns     []string

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -74,7 +74,6 @@ func init() {
 	rootCmd.Flags().DurationP("timeout", "t", 30*time.Second, "HTTP request timeout")
 	rootCmd.Flags().StringP("user-agent", "u", "LinkTadoru/1.0", "HTTP User-Agent header")
 	rootCmd.Flags().Bool("ignore-robots-txt", false, "Ignore robots.txt rules")
-	rootCmd.Flags().Bool("follow-external-hosts", false, "Allow all hosts with an allowed scheme (excludes still apply)")
 	rootCmd.Flags().IntP("limit", "l", 0, "Stop after N pages (0=unlimited)")
 	rootCmd.Flags().Int("max-depth", 0, "Maximum first-discovery depth (0=unlimited, seeds=0)")
 	rootCmd.Flags().Int64("max-response-size", 10*1024*1024, "Max response body size in bytes")
@@ -113,7 +112,6 @@ func init() {
 		{"request_timeout", "timeout"},
 		{"user_agent", "user-agent"},
 		{"ignore_robots_txt", "ignore-robots-txt"},
-		{"follow_external_hosts", "follow-external-hosts"},
 		{"limit", "limit"},
 		{"max_depth", "max-depth"},
 		{"max_response_size", "max-response-size"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,16 +52,15 @@ type Auth struct {
 // CrawlConfig holds crawler configuration
 type CrawlConfig struct {
 	// Basic crawling parameters
-	SeedURLs            []string      `mapstructure:"seed_urls" yaml:"seed_urls"`                         // Starting URLs for crawling
-	Concurrency         int           `mapstructure:"concurrency" yaml:"concurrency"`                     // Number of concurrent workers
-	RequestDelay        float64       `mapstructure:"request_delay" yaml:"request_delay"`                 // Delay between requests
-	RequestTimeout      time.Duration `mapstructure:"request_timeout" yaml:"request_timeout"`             // HTTP request timeout
-	UserAgent           string        `mapstructure:"user_agent" yaml:"user_agent"`                       // HTTP User-Agent header
-	IgnoreRobotsTxt     bool          `mapstructure:"ignore_robots_txt" yaml:"ignore_robots_txt"`         // Whether to ignore robots.txt
-	FollowExternalHosts bool          `mapstructure:"follow_external_hosts" yaml:"follow_external_hosts"` // Whether to crawl external hosts
-	Limit               int           `mapstructure:"limit" yaml:"limit"`                                 // Stop after N pages
-	MaxDepth            int           `mapstructure:"max_depth" yaml:"max_depth"`                         // 0 = unlimited; positive values include that discovery depth
-	MaxResponseSize     int64         `mapstructure:"max_response_size" yaml:"max_response_size"`         // Max response body size in bytes (0 = default 10MiB)
+	SeedURLs        []string      `mapstructure:"seed_urls" yaml:"seed_urls"`                 // Starting URLs for crawling
+	Concurrency     int           `mapstructure:"concurrency" yaml:"concurrency"`             // Number of concurrent workers
+	RequestDelay    float64       `mapstructure:"request_delay" yaml:"request_delay"`         // Delay between requests
+	RequestTimeout  time.Duration `mapstructure:"request_timeout" yaml:"request_timeout"`     // HTTP request timeout
+	UserAgent       string        `mapstructure:"user_agent" yaml:"user_agent"`               // HTTP User-Agent header
+	IgnoreRobotsTxt bool          `mapstructure:"ignore_robots_txt" yaml:"ignore_robots_txt"` // Whether to ignore robots.txt
+	Limit           int           `mapstructure:"limit" yaml:"limit"`                         // Stop after N pages
+	MaxDepth        int           `mapstructure:"max_depth" yaml:"max_depth"`                 // 0 = unlimited; positive values include that discovery depth
+	MaxResponseSize int64         `mapstructure:"max_response_size" yaml:"max_response_size"` // Max response body size in bytes (0 = default 10MiB)
 
 	// Authentication
 	Auth *Auth `mapstructure:"auth" yaml:"auth"` // Authentication configuration
@@ -88,17 +87,16 @@ type CrawlConfig struct {
 // DefaultConfig returns a configuration with default values
 func DefaultConfig() *CrawlConfig {
 	return &CrawlConfig{
-		Concurrency:         2,   // Reduced from 10 to 2
-		RequestDelay:        0.1, // 100ms in seconds // Reduced from 1s to 0.1s
-		RequestTimeout:      30 * time.Second,
-		UserAgent:           "LinkTadoru/1.0",
-		IgnoreRobotsTxt:     false,
-		FollowExternalHosts: false,            // Default to same-host only for safety
-		Limit:               0,                // unlimited
-		MaxDepth:            0,                // unlimited
-		MaxResponseSize:     10 * 1024 * 1024, // 10 MiB response body cap
-		DatabasePath:        "./linktadoru.db",
-		AllowedSchemes:      []string{"https://", "http://"}, // Default allowed URL schemes
+		Concurrency:     2,   // Reduced from 10 to 2
+		RequestDelay:    0.1, // 100ms in seconds // Reduced from 1s to 0.1s
+		RequestTimeout:  30 * time.Second,
+		UserAgent:       "LinkTadoru/1.0",
+		IgnoreRobotsTxt: false,
+		Limit:           0,                // unlimited
+		MaxDepth:        0,                // unlimited
+		MaxResponseSize: 10 * 1024 * 1024, // 10 MiB response body cap
+		DatabasePath:    "./linktadoru.db",
+		AllowedSchemes:  []string{"https://", "http://"}, // Default allowed URL schemes
 		// Logging defaults
 		LogLevel:      "info",
 		LogFile:       "",  // Empty means no file logging by default

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,10 +30,6 @@ func TestDefaultConfig(t *testing.T) {
 		t.Errorf("Expected ignore robots.txt false, got %v", cfg.IgnoreRobotsTxt)
 	}
 
-	if cfg.FollowExternalHosts {
-		t.Errorf("Expected follow external hosts false, got %v", cfg.FollowExternalHosts)
-	}
-
 	if cfg.Limit != 0 {
 		t.Errorf("Expected limit 0, got %d", cfg.Limit)
 	}

--- a/internal/crawler/audit_fixes_test.go
+++ b/internal/crawler/audit_fixes_test.go
@@ -5,10 +5,8 @@ package crawler
 // robots.txt crawl-delay wiring.
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -94,31 +92,6 @@ func TestNewCrawlerRejectsInvalidPatterns(t *testing.T) {
 	cfg.ExcludePatterns = []string{"(unclosed"}
 	if _, err := NewCrawler(cfg, &MockStorage{}); err == nil || !strings.Contains(err.Error(), "exclude pattern") {
 		t.Errorf("invalid exclude pattern: err = %v, want exclude pattern error", err)
-	}
-}
-
-func TestNewCrawlerWarnsWhenFollowExternalIgnoresIncludes(t *testing.T) {
-	var output bytes.Buffer
-	previousLogger := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
-	t.Cleanup(func() { slog.SetDefault(previousLogger) })
-
-	cfg := &config.CrawlConfig{
-		Concurrency:         1,
-		RequestDelay:        0.1,
-		RequestTimeout:      time.Second,
-		UserAgent:           "LinkTadoru-Test/1.0",
-		FollowExternalHosts: true,
-		IncludePatterns:     []string{`^https://included\.example/only$`},
-	}
-	if _, err := NewCrawler(cfg, &MockStorage{}); err != nil {
-		t.Fatal(err)
-	}
-
-	logOutput := output.String()
-	if !strings.Contains(logOutput, "include_patterns do not narrow this mode") ||
-		!strings.Contains(logOutput, "use exclude_patterns to restrict it") {
-		t.Fatalf("warning did not explain allow-all behavior: %s", logOutput)
 	}
 }
 

--- a/internal/crawler/crawler.go
+++ b/internal/crawler/crawler.go
@@ -100,17 +100,12 @@ func NewCrawler(config *config.CrawlConfig, storage Storage) (*DefaultCrawler, e
 		config.AllowedSchemes,
 		config.IncludePatterns,
 		config.ExcludePatterns,
-		config.FollowExternalHosts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL policy: %w", err)
 	}
 	if len(config.IncludePatterns) > 0 {
-		if config.FollowExternalHosts {
-			slog.Warn("follow_external_hosts allows every URL with an allowed scheme; include_patterns do not narrow this mode; use exclude_patterns to restrict it")
-		} else {
-			slog.Warn("include_patterns add URL ranges; seed origins remain allowed; use exclude_patterns to narrow them")
-		}
+		slog.Warn("include_patterns add URL ranges; seed origins remain allowed; use exclude_patterns to narrow them")
 	}
 
 	crawler := &DefaultCrawler{

--- a/internal/crawler/external_url_test.go
+++ b/internal/crawler/external_url_test.go
@@ -20,7 +20,7 @@ func TestPageProcessorExternalLinks(t *testing.T) {
 	<a href="/internal-page">Internal relative</a>
 	<a href="http://example.com/page1">Internal absolute</a>
 	
-	<!-- External links (should not be saved when follow_external_hosts=false) -->
+	<!-- External links are controlled by the crawler URL policy. -->
 	<a href="https://google.com/search">External: Google</a>
 	<a href="https://github.com/user/repo">External: GitHub</a>
 	<a href="http://httpbin.org/get">External: HTTPBin</a>

--- a/internal/crawler/integration_test.go
+++ b/internal/crawler/integration_test.go
@@ -417,14 +417,13 @@ func TestSameHostFiltering(t *testing.T) {
 
 	// Test default behavior (same-host only)
 	config := &config.CrawlConfig{
-		SeedURLs:            []string{server1.URL},
-		Limit:               10,
-		Concurrency:         1,
-		RequestDelay:        0.01, // 10ms in seconds
-		RequestTimeout:      2 * time.Second,
-		UserAgent:           "LinkTadoru-Test/1.0",
-		IgnoreRobotsTxt:     true,
-		FollowExternalHosts: false, // Default - same host only
+		SeedURLs:        []string{server1.URL},
+		Limit:           10,
+		Concurrency:     1,
+		RequestDelay:    0.01, // 10ms in seconds
+		RequestTimeout:  2 * time.Second,
+		UserAgent:       "LinkTadoru-Test/1.0",
+		IgnoreRobotsTxt: true,
 	}
 
 	store := &HostFilteringTestStorage{}
@@ -441,49 +440,6 @@ func TestSameHostFiltering(t *testing.T) {
 	}
 	if crawler.urlPolicy.allows(server2.URL + "/external") {
 		t.Errorf("External host URL should be blocked")
-	}
-}
-
-// TestExternalHostsEnabled tests that external hosts are crawled when enabled
-func TestExternalHostsEnabled(t *testing.T) {
-	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`<html><body>Internal Page</body></html>`))
-	}))
-	defer server1.Close()
-
-	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`<html><body>External Page</body></html>`))
-	}))
-	defer server2.Close()
-
-	// Test with external hosts enabled
-	config := &config.CrawlConfig{
-		SeedURLs:            []string{server1.URL},
-		Limit:               10,
-		Concurrency:         1,
-		RequestDelay:        0.01, // 10ms in seconds
-		RequestTimeout:      2 * time.Second,
-		UserAgent:           "LinkTadoru-Test/1.0",
-		IgnoreRobotsTxt:     true,
-		FollowExternalHosts: true, // Enable external hosts
-	}
-
-	store := &HostFilteringTestStorage{}
-	crawler, err := NewCrawler(config, store)
-	if err != nil {
-		t.Fatalf("Failed to create crawler: %v", err)
-	}
-
-	// Test that both internal and external hosts are allowed
-	if !crawler.urlPolicy.allows(server1.URL + "/page1") {
-		t.Errorf("Same host URL should be allowed")
-	}
-	if !crawler.urlPolicy.allows(server2.URL + "/external") {
-		t.Errorf("External host URL should be allowed when follow_external_hosts is true")
 	}
 }
 

--- a/internal/crawler/issue46_integration_test.go
+++ b/internal/crawler/issue46_integration_test.go
@@ -145,7 +145,7 @@ func TestCrawlRespectsIncludePatterns(t *testing.T) {
 	}
 }
 
-func TestFollowExternalHostsIgnoresIncludesButHonorsExcludes(t *testing.T) {
+func TestCrawlIncludeExcludesAndStripsHeadersOffOrigin(t *testing.T) {
 	var externalHits atomic.Int32
 	var leakedSecret atomic.Bool
 	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -169,8 +169,7 @@ func TestFollowExternalHostsIgnoresIncludesButHonorsExcludes(t *testing.T) {
 
 	cfg := baseCfg()
 	cfg.SeedURLs = []string{seed.URL}
-	cfg.FollowExternalHosts = true
-	cfg.IncludePatterns = []string{`^https://included\.example/only$`}
+	cfg.IncludePatterns = []string{`^` + regexp.QuoteMeta(external.URL) + `/.*$`}
 	cfg.ExcludePatterns = []string{`/private/`}
 	cfg.Headers = []string{"X-Test-Secret: secret"}
 

--- a/internal/crawler/redirect_test.go
+++ b/internal/crawler/redirect_test.go
@@ -20,17 +20,17 @@ import (
 
 // newRedirectTestCrawler builds a crawler over the given seed so the redirect
 // policy is wired exactly as production does it.
-func newRedirectTestCrawler(t *testing.T, seedURL string, followExternal bool) *DefaultCrawler {
+func newRedirectTestCrawler(t *testing.T, seedURL string, includes ...string) *DefaultCrawler {
 	t.Helper()
 
 	cfg := &config.CrawlConfig{
-		SeedURLs:            []string{seedURL},
-		UserAgent:           "LinkTadoru-Test/1.0",
-		RequestTimeout:      5 * time.Second,
-		MaxResponseSize:     1 << 20,
-		AllowedSchemes:      []string{"https://", "http://"},
-		FollowExternalHosts: followExternal,
-		IgnoreRobotsTxt:     true,
+		SeedURLs:        []string{seedURL},
+		UserAgent:       "LinkTadoru-Test/1.0",
+		RequestTimeout:  5 * time.Second,
+		MaxResponseSize: 1 << 20,
+		AllowedSchemes:  []string{"https://", "http://"},
+		IncludePatterns: includes,
+		IgnoreRobotsTxt: true,
 	}
 
 	crawler, err := NewCrawler(cfg, nil)
@@ -151,7 +151,7 @@ func TestRedirectSameHostIsFollowed(t *testing.T) {
 	}))
 	defer server.Close()
 
-	crawler := newRedirectTestCrawler(t, server.URL, false)
+	crawler := newRedirectTestCrawler(t, server.URL)
 
 	resp, err := crawler.httpClient.Get(context.Background(), server.URL+"/start")
 	if err != nil {
@@ -165,8 +165,8 @@ func TestRedirectSameHostIsFollowed(t *testing.T) {
 	}
 }
 
-// With follow_external_hosts=false a redirect to another host must fail, and
-// the external target must never be contacted.
+// Without an include pattern a redirect to another host must fail, and the
+// external target must never be contacted.
 func TestRedirectToExternalHostIsRejected(t *testing.T) {
 	var externalHits int32
 	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +180,7 @@ func TestRedirectToExternalHostIsRejected(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	crawler := newRedirectTestCrawler(t, origin.URL, false)
+	crawler := newRedirectTestCrawler(t, origin.URL)
 
 	_, err := crawler.httpClient.Get(context.Background(), origin.URL+"/start")
 	if !errors.Is(err, ErrRedirectNotAllowed) {
@@ -191,8 +191,8 @@ func TestRedirectToExternalHostIsRejected(t *testing.T) {
 	}
 }
 
-// With follow_external_hosts=true the redirect is allowed, but the credentials
-// configured for the origin must not be forwarded to the new host.
+// An included cross-origin redirect is allowed, but credentials configured for
+// the origin must not be forwarded to the new host.
 func TestRedirectToExternalHostDropsCredentials(t *testing.T) {
 	var got http.Header
 	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -207,13 +207,13 @@ func TestRedirectToExternalHostDropsCredentials(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	crawler := newRedirectTestCrawler(t, origin.URL, true)
+	crawler := newRedirectTestCrawler(t, origin.URL, "^"+regexp.QuoteMeta(external.URL)+"/.*$")
 	crawler.httpClient.SetAPIKeyAuth("X-Api-Key", "super-secret")
 	crawler.httpClient.SetCustomHeaders(map[string]string{"X-Internal-Token": "also-secret"})
 
 	resp, err := crawler.httpClient.Get(context.Background(), origin.URL+"/start")
 	if err != nil {
-		t.Fatalf("external redirect was rejected despite follow_external_hosts=true: %v", err)
+		t.Fatalf("included external redirect was rejected: %v", err)
 	}
 	if want := external.URL + "/landing"; resp.FinalURL != want {
 		t.Errorf("FinalURL = %q, want %q", resp.FinalURL, want)
@@ -244,7 +244,7 @@ func TestRedirectDropsBearerAuthorization(t *testing.T) {
 	}))
 	defer origin.Close()
 
-	crawler := newRedirectTestCrawler(t, origin.URL, true)
+	crawler := newRedirectTestCrawler(t, origin.URL, "^"+regexp.QuoteMeta(external.URL)+"/.*$")
 	crawler.httpClient.SetBearerAuth("token-value")
 
 	if _, err := crawler.httpClient.Get(context.Background(), origin.URL+"/start"); err != nil {

--- a/internal/crawler/url_filter_test.go
+++ b/internal/crawler/url_filter_test.go
@@ -7,7 +7,6 @@ func TestURLPolicyImplicitOriginAndExclude(t *testing.T) {
 		[]string{"https://", "http://"},
 		nil,
 		[]string{`/ika/`},
-		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +40,6 @@ func TestURLPolicyIncludeRequiresFullStringMatch(t *testing.T) {
 		[]string{"https://"},
 		[]string{`^https://good\.example/$|https://extra\.example/search`},
 		nil,
-		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -64,26 +62,25 @@ func TestURLPolicyIncludeRequiresFullStringMatch(t *testing.T) {
 }
 
 func TestURLPolicyRejectsLegacyRelativeInclude(t *testing.T) {
-	if _, err := newURLPolicy(nil, []string{`/products/`}, nil, false); err == nil {
+	if _, err := newURLPolicy(nil, []string{`/products/`}, nil); err == nil {
 		t.Fatal("relative include pattern was accepted")
 	}
 }
 
-func TestURLPolicyFollowExternalIgnoresIncludeAndHonorsExclude(t *testing.T) {
+func TestURLPolicyExcludeOverridesInclude(t *testing.T) {
 	policy, err := newURLPolicy(
 		nil,
-		[]string{`^https://included\.example/only$`},
+		[]string{`^https://included\.example/.*$`},
 		[]string{`/private/`},
-		true,
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !policy.allows("https://other.example/public/page") {
-		t.Fatal("include_patterns unexpectedly narrowed follow_external_hosts")
+	if !policy.allows("https://included.example/public/page") {
+		t.Fatal("include pattern did not allow the matching URL")
 	}
-	if policy.allows("https://other.example/private/page") {
-		t.Fatal("exclude did not override follow_external_hosts")
+	if policy.allows("https://included.example/private/page") {
+		t.Fatal("exclude did not override include")
 	}
 }
 

--- a/internal/crawler/url_policy.go
+++ b/internal/crawler/url_policy.go
@@ -16,10 +16,9 @@ type urlPolicy struct {
 	implicitOrigins map[string]struct{}
 	includes        []*regexp.Regexp
 	excludes        []*regexp.Regexp
-	allowAll        bool
 }
 
-func newURLPolicy(allowedSchemes, includes, excludes []string, allowAll bool) (*urlPolicy, error) {
+func newURLPolicy(allowedSchemes, includes, excludes []string) (*urlPolicy, error) {
 	schemes := make(map[string]struct{})
 	if len(allowedSchemes) == 0 {
 		allowedSchemes = []string{"https://", "http://"}
@@ -53,7 +52,6 @@ func newURLPolicy(allowedSchemes, includes, excludes []string, allowAll bool) (*
 		implicitOrigins: make(map[string]struct{}),
 		includes:        includePatterns,
 		excludes:        excludePatterns,
-		allowAll:        allowAll,
 	}, nil
 }
 
@@ -94,10 +92,7 @@ func (p *urlPolicy) allows(raw string) bool {
 		return false
 	}
 
-	allowed := p.allowAll
-	if !allowed {
-		_, allowed = p.implicitOrigins[origin]
-	}
+	_, allowed := p.implicitOrigins[origin]
 	if !allowed {
 		for _, re := range p.includes {
 			if re.MatchString(raw) {

--- a/linktadoru.yml.example
+++ b/linktadoru.yml.example
@@ -7,7 +7,6 @@ request_delay: 0.1           # Delay between requests in seconds (default: 0.1, 
 request_timeout: "30s"       # HTTP request timeout (Go duration, e.g. "30s", "1m")
 user_agent: "LinkTadoru/1.0"       # User-Agent header (version will be dynamically set if not specified)
 ignore_robots_txt: false    # Whether to ignore robots.txt rules (default: respect robots.txt)
-follow_external_hosts: false # Whether to crawl external hosts (default: same-host only for safety)
 limit: 0                    # Stop after N pages (0 = unlimited)
 max_depth: 0                # 0 = unlimited; positive N includes first-discovery depth N
 max_response_size: 10485760 # Max response body size in bytes (default: 10 MiB); larger pages are recorded as errors
@@ -101,7 +100,3 @@ headers:
 #   - '/login'
 #   - '/admin'
 #   - '\.pdf$'
-
-# Cross-site crawling (follow external links):
-# follow_external_hosts: true
-# limit: 100  # Recommended when crawling multiple sites


### PR DESCRIPTION
## Summary

- remove the follow_external_hosts CLI and configuration switch
- keep one URL policy based on seed origins, explicit absolute-URL includes, and deny-winning excludes
- update tests, documentation, examples, and the v0.12.0 changelog

## Why

follow_external_hosts bypassed include_patterns and made crawl scope harder to understand. External ranges can already be expressed explicitly with include_patterns, so the separate allow-all branch is unnecessary.

The old CLI flag is now rejected as unknown. Existing YAML and environment values are ignored, and users should migrate external ranges to include_patterns.

## Validation

- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- git diff --check

Closes #84